### PR TITLE
Added Windows CMD support by importing colorama into output.py

### DIFF
--- a/green/output.py
+++ b/green/output.py
@@ -2,6 +2,10 @@ from __future__ import unicode_literals
 import logging
 import sys
 import termstyle
+import colorama
+
+# Make it work on Windows, too
+colorama.init()
 
 global debug_level
 debug_level = 0


### PR DESCRIPTION
Colorama plays nicely with Termcolor. It was a simple change to get Windows support for green.

https://pypi.python.org/pypi/colorama

When accepted, closes issue #18 
