### PR TITLE
loader: Don't add tests which have __test__ set to False

### DIFF
--- a/green/loader.py
+++ b/green/loader.py
@@ -121,11 +121,21 @@ def findDottedModuleAndParentDir(file_path):
     return (dotted_module, parent_dir)
 
 
+def isNoseDisabledCase(test_case_class, attrname):
+    test_func = getattr(test_case_class, attrname)
+    nose_enabled = getattr(test_func, "__test__", None)
+
+    if nose_enabled is False:
+        return True
+    else:
+        return False
+
 def loadFromTestCase(test_case_class):
     debug("Examining test case {}".format(test_case_class.__name__), 3)
     test_case_names = list(filter(
         lambda attrname: (attrname.startswith('test') and
-                          callable(getattr(test_case_class, attrname))),
+                          callable(getattr(test_case_class, attrname)) and
+                          not isNoseDisabledCase(test_case_class, attrname)),
         dir(test_case_class)))
     debug("Test case names: {}".format(test_case_names))
     test_case_names.sort(

--- a/green/test/test_loader.py
+++ b/green/test/test_loader.py
@@ -264,6 +264,17 @@ class TestLoadFromTestCase(unittest.TestCase):
                          set(['test_method1', 'test_method2']))
 
 
+    def test_nose_disabled_attribute(self):
+        "Tests disabled by nose generators dont get loaded"
+        class HasDisabled(unittest.TestCase):
+            def test_method(self):
+                pass
+
+            test_method.__test__ = False
+
+        suite = loader.loadFromTestCase(HasDisabled)
+        self.assertEqual(suite.countTestCases(), 0)
+
 
 class TestLoadFromModuleFilename(unittest.TestCase):
 


### PR DESCRIPTION
This attribute is set by nose.tools for functions that shouldn't
be considered tests (usually because they're a base for a generated
test function).

This change enables nose_parameterized with green.

Fixes #39