### PR TITLE
Added --name-pattern option

### DIFF
--- a/green/cmdline.py
+++ b/green/cmdline.py
@@ -62,7 +62,11 @@ def main(testing=False, coverage_testing=False):
     if testing:
         test_suite = None
     else:
-        test_suite = loadTargets(args.targets, file_pattern = args.pattern)
+        test_suite = loadTargets(
+            args.targets,
+            file_pattern = args.pattern,
+            name_pattern = args.name_pattern,
+        )
 
     # We didn't even load 0 tests...
     if not test_suite:

--- a/green/config.py
+++ b/green/config.py
@@ -53,6 +53,7 @@ default_args = argparse.Namespace( # pragma: no cover
         failfast        = False,
         config          = None,  # Not in configs
         pattern         = 'test*.py',
+        name_pattern    = None,
         run_coverage    = False,
         omit            = None,
         completion_file = False,
@@ -197,6 +198,8 @@ CONFIG FILES
     store_opt(other_args.add_argument('-p', '--pattern', action='store',
         metavar='PATTERN',
         help="Pattern to match test files. Default is test*.py"))
+    store_opt(other_args.add_argument('-n', '--name-pattern', action='store',
+        metavar='PATTERN', help="Pattern to match test method names."))
 
     cov_args = parser.add_argument_group(
         "Coverage Options ({})".format(coverage_version))
@@ -337,7 +340,7 @@ def mergeConfig(args, testing=False, coverage_testing=False): # pragma: no cover
             config_getter = config.getboolean
         elif name in ['subprocesses', 'debug', 'verbose']:
             config_getter = config.getint
-        elif name in ['omit', 'warnings', 'pattern']:
+        elif name in ['omit', 'warnings', 'pattern', 'name_pattern']:
             config_getter = config.get
         elif name in ['targets', 'help', 'config']:
             pass # Some options only make sense coming on the command-line.

--- a/green/loader.py
+++ b/green/loader.py
@@ -239,7 +239,7 @@ def discover(current_path, file_pattern='test*.py'):
     return ((suite.countTestCases() and suite) or None)
 
 
-def loadTargets(targets, file_pattern='test*.py'):
+def loadTargets(targets, file_pattern='test*.py', name_pattern=None):
     # If a string was passed in, put it into a list.
     if type(targets) != list:
         targets = [targets]
@@ -261,11 +261,35 @@ def loadTargets(targets, file_pattern='test*.py'):
         debug("Found {} test{} for target '{}'".format(
             num_tests, '' if (num_tests == 1) else 's', target))
 
-    if suites:
-        return GreenTestSuite(suites)
-    else:
+    if not suites:
         return None
 
+    suite = GreenTestSuite(suites)
+    if name_pattern is None:
+        return suite
+    else:
+        name_regex = re.compile(name_pattern)
+        return name_filtered(suite, name_regex)
+
+def name_filtered(suite, name_regex):
+    """
+    Takes a GreenTestSuite and a compiled regex. Creates a new GreenTestSuite
+    consisting only of test methods having names that satisfy the regex.
+    Returns None if the new suite is empty.
+    """
+    new_suite = GreenTestSuite()
+    for x in suite:
+        if isinstance(x, GreenTestSuite):
+            sub_suite = name_filtered(x, name_regex)
+            if sub_suite and sub_suite.countTestCases():
+                new_suite.addTest(sub_suite)
+        else:
+            if name_regex is None or name_regex.search(x._testMethodName):
+                new_suite.addTest(x)
+    if new_suite.countTestCases():
+        return new_suite
+    else:
+        return None
 
 def loadTarget(target, file_pattern='test*.py'):
     """


### PR DESCRIPTION
- The option allows the user to run specific tests: only those with
  names that satisfy a regex.

- Have not added any tests yet. First wanted to gauge interest and
  get any feedback.

- An example run of the green test suite, using the new option:

        $ ./g -n empty -v
        green.test.test_loader
          TestLoadTargets
        .   test_emptyDirAbsolute
        .   test_emptyDirDot
        .   test_emptyDirRelative
        green.test.test_runner
          TestSubprocesses
        .   test_empty
        green.test.test_suite
          TestGreenTestSuite
        .   test_empty

        Ran 5 tests in 0.112s

        OK (passes=5)
