### PR TITLE
Report to stderr instead of stdout

### DIFF
--- a/green/cmdline.py
+++ b/green/cmdline.py
@@ -35,7 +35,7 @@ def main(testing=False, coverage_testing=False):
     if args.debug:
         green.output.debug_level = args.debug
 
-    stream = GreenStream(sys.stdout, html = args.html)
+    stream = GreenStream(sys.stderr, html = args.html)
 
     # Location of shell completion file
     if args.completion_file:


### PR DESCRIPTION
When green is used in Makefile, his report get buffered until all tests will not be executed.

Example to reproduce:

```
check:
	green <some-project-with-a-lot-of-tests>
```