### PR TITLE
Don't print \r if we're not connected to a terminal.

### DIFF
--- a/green/output.py
+++ b/green/output.py
@@ -200,3 +200,6 @@ class GreenStream(object):
             space_char = '&nbsp;'
         return (outcome_char + space_char * actual_spaces + line)
 
+    def isatty(self):
+        """Wrap internal self.stream.isatty."""
+        return self.stream.isatty()

--- a/green/result.py
+++ b/green/result.py
@@ -314,7 +314,7 @@ class GreenTestResult(BaseTestResult):
                 self.stream.writeln(self.colors.className(
                     self.stream.formatText(current_class, indent=1)))
             # Test name or description
-            if not self.colors.html:
+            if not self.colors.html and self.stream.isatty():
                 # In the terminal, we will write a placeholder, and then
                 # rewrite it in color after the test has run.
                 self.stream.write(
@@ -340,7 +340,7 @@ class GreenTestResult(BaseTestResult):
         test = proto_test(test)
         if self.showAll:
             # Move the cursor back to the start of the line in terminal mode
-            if not self.colors.html:
+            if not self.colors.html and self.stream.isatty():
                 self.stream.write('\r')
             # Escape the HTML that may be in the docstring
             test_description = test.getDescription(self.verbose)


### PR DESCRIPTION
If stdout is connected to a pipe or file, this will result in
duplicate lines.

Check to make sure we're connected to a terminal first before
printing \r and other "status" like lines.

Fixes #52