### PR TITLE
Quote $@ in the g script

### DIFF
--- a/g
+++ b/g
@@ -15,4 +15,4 @@ elif [[ -e `which python$1` ]] ; then
 fi
 
 # Run the command-line version of green
-PYTHONPATH="." $PYTHON -m green.cmdline $@
+PYTHONPATH="." $PYTHON -m green.cmdline "$@"


### PR DESCRIPTION
- Quoting allows args with wildcards to pass through to green
  successfully.

- See http://stackoverflow.com/questions/2761723 for details.