### PR TITLE
RFC: Detect when suites need to be run in serial

### DIFF
--- a/green/result.py
+++ b/green/result.py
@@ -194,6 +194,10 @@ class ProtoTestResult(BaseTestResult):
         "Called when a test passed, but we expected a failure"
         self.unexpectedSuccesses.append(proto_test(test))
 
+    @property
+    def any_errors(self, ignored=None):
+        "True if anything failed due to an error"
+        return self.errors > 0
 
 
 class GreenTestResult(BaseTestResult):

--- a/green/test/test_subprocess.py
+++ b/green/test/test_subprocess.py
@@ -11,6 +11,11 @@ except:
 from green.subprocess import SubprocessLogger, DaemonlessProcess, poolRunner
 from green import subprocess
 
+try:
+    from Queue import Queue
+except:
+    from queue import Queue
+
 
 class TestSubprocessLogger(unittest.TestCase):
 
@@ -112,9 +117,11 @@ class A(unittest.TestCase):
 """)
         fh.close()
         module_name = basename + '.test_pool_runner_dotted.A.testPass'
-        result = poolRunner(module_name, 1)
+        result = Queue()
+        poolRunner(module_name, result, 1)
         subprocess.coverage = saved_coverage
-        self.assertEqual(len(result.passing), 1)
+        result.get()
+        self.assertEqual(len(result.get().passing), 1)
 
 
     def test_SyntaxErrorInUnitTest(self):
@@ -133,9 +140,11 @@ class A(unittest.TestCase):
         fh.write("aoeu")
         fh.close()
         module_name = basename + '.test_pool_syntax_error'
-        result = poolRunner(module_name, 1)
+        result = Queue()
+        poolRunner(module_name, result, 1)
         subprocess.coverage = saved_coverage
-        self.assertEqual(len(result.errors), 1)
+        result.get()
+        self.assertEqual(len(result.get().errors), 1)
 
 
     def test_error(self):
@@ -159,7 +168,9 @@ class A(unittest.TestCase):
 """)
         fh.close()
         module_name = basename + '.test_pool_runner_dotted_fail.A.testError'
-        result = poolRunner(module_name)
-        self.assertEqual(len(result.errors), 1)
+        result = Queue()
+        poolRunner(module_name, result)
+        result.get()
+        self.assertEqual(len(result.get().errors), 1)
 
 


### PR DESCRIPTION
This is an RFC style patch to run suites that define
setUpClass, tearDownClass, setUpModule and tearDownModule
in serial vis-a-vis each other.

There's a few rough edges, and a few places where I need
some comments and ideas on what to do.

The biggest missing part so far is that KeyboardInterrupt
handling isn't there. If there's a container in Python
which represents "value or exception" kind of like
multiprocessing's AsyncResult, then that'd be nice.

toParallelTestTargets subdivides a GreenTestSuite into
a set of strings representing loadable targets for the
runner. It actually subdivides all the way at the moment
until we reach something that looks like a unittest.TestCase,
at which point it checks that class and its module to see
if any serial-indicating methods are defined such that
only the class or module name should be returned.

poolRunner was also adjusted to return its results via a
queue - it may run multiple tests now and needs to indicate
to the parent runner both when a test has started and
finished.