### PR TITLE
enable "python -m green" - #91

### DIFF
--- a/green/__main__.py
+++ b/green/__main__.py
@@ -1,0 +1,7 @@
+from __future__ import absolute_import
+
+import sys
+
+from .cmdline import main
+
+sys.exit(main())


### PR DESCRIPTION
Add `__main__.py` to support alternative usage: `python -m green` - issue #91
