### PR TITLE
Use flake8-putty to allow existing flake8 errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,9 @@ install:
   - "pip install ."
   - "pip install virtualenv"
   - "pip install coveralls"
+  - pip install flake8-putty
 script:
+  - make flakes
   - "make test"
 after_success: "if [ $TRAVIS_OS_NAME == linux ] ; then coveralls ; fi"
 matrix:

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ test: test-versions test-installed test-coverage
 	# test-coverage needs to be last in deps, don't clean after it runs!
 	@echo "\n(test) completed\n"
 
+flakes:
+	flake8
+
 test-local:
 	@sudo -H pip install -r requirements-optional.txt
 	-@sudo -H pip uninstall green

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,30 @@
 [metadata]
 description-file = README.md
 
+[flake8]
+ignore = C101,D100,D200,D205,D400,E261,E303,FI10,FI11,FI12,FI13,FI15,FI54,I100,N802,P101,Q000
+max_line_length = 99
+putty-ignore =
+    setup.py : +E123,E128,E203,E231,E251,FI14,I101,I201
+    green/__init__.py : +D104,I201
+    green/__main__.py : +FI14,FI51
+    green/cmdline.py : +B901,D103,E251,I201,R201,T001
+    green/config.py : +B901,D102,D105,D204,E123,E125,E126,E128,E221,E226,E231,E251,E302,FI53,R201,R306,T001
+    green/djangorunner.py : +D101,D103,F401
+    green/examples.py : +D101,D401,I201,T001
+    green/exceptions.py : +D101
+    green/loader.py : +B901,D103,D401,E126,E128,E221,E301,E501,E711,E712,I201,N806,R201,R306,T000
+    green/output.py : +D102,D204,D401,E711,I201
+    green/process.py : +B901,D101,D102,D103,D105,D204,E124,E126,E128,E221,E226,E265,E301,E302,E501,I101,I201,R201,R306,T001
+    green/result.py : +D102,D105,D204,D401,E123,E126,E128,E221,E251,FI53
+    green/runner.py : +B901,D102,D204,E126,E128,FI53,I101,R201
+    green/suite.py : +B901,D102,D204,E124,E128,E129,FI53,I101,N806,R201
+    green/terminal.py : +B901,E127,FI14,R201,R306
+    green/version.py : +B901,D103,I201,R201
+    example/proj/ : +D,FI,I,E302
+    green/test/ : +D,FI,I,B,R,N,C,E126,E128,E221,E301,W391
+    green/test/test_cmdline.py : +F401
+    green/test/test_config.py : +E111,E241
+    green/test/test_loader.py : +E123,E711
+    green/test/test_result.py : +E231
+    green/test/test_runner.py : +E265,E302,E702


### PR DESCRIPTION
Records existing errors per file, for many common
flake8 plugins, preventing new flake8 errors.