### PR TITLE
Add --quiet-stdout option

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ init:
     - "ECHO %PYTHON%"
     - ps: "ls C:/Python*"
 install:
-      - ps: (new-object net.webclient).DownloadFile('https://raw.github.com/pypa/pip/master/contrib/get-pip.py', 'C:/get-pip.py')
+      - ps: (new-object net.webclient).DownloadFile('https://bootstrap.pypa.io/get-pip.py', 'C:/get-pip.py')
       - "%PYTHON%/python.exe C:/get-pip.py"
       - "%PYTHON%/Scripts/pip.exe install -r requirements.txt"
 test_script:

--- a/cli-options.txt
+++ b/cli-options.txt
@@ -48,6 +48,8 @@ Output Options:
   -a, --allow-stdout    Instead of capturing the stdout and stderr and
                         presenting it in the summary of results, let it come
                         through.
+  -q, --quiet-stdout    Instead of capturing the stdout and stderr and presenting it in
+                        the summary of results, discard it completly for successful tests. --allow-stdout option overrides it.
   -k, --no-skip-report  Don't print the report of skipped tests after testing
                         is done. Skips will still show up in the progress
                         report and summary count.

--- a/green/config.py
+++ b/green/config.py
@@ -49,6 +49,7 @@ default_args             = argparse.Namespace( # pragma: no cover
         termcolor        = None,
         notermcolor      = None,
         allow_stdout     = False,
+        quiet_stdout     = False,
         no_skip_report   = False,
         help             = False, # Not in configs
         version          = False,
@@ -201,6 +202,11 @@ def parseArguments(): # pragma: no cover
     store_opt(out_args.add_argument('-a', '--allow-stdout', action='store_true',
         help=("Instead of capturing the stdout and stderr and presenting it in "
         "the summary of results, let it come through."),
+        default=argparse.SUPPRESS))
+    store_opt(out_args.add_argument('-q', '--quiet-stdout', action='store_true',
+        help=("Instead of capturing the stdout and stderr and presenting it in "
+        "the summary of results, discard it completly for successful tests. "
+        "--allow-stdout option overrides it."),
         default=argparse.SUPPRESS))
     store_opt(out_args.add_argument('-k', '--no-skip-report',
         action='store_true', help=("Don't print the report of skipped tests "
@@ -393,9 +399,9 @@ def mergeConfig(args, testing=False): # pragma: no cover
     for name, default_value in dict(default_args._get_kwargs()).items():
         # Config options overwrite default options
         config_getter = None
-        if name in ['termcolor', 'notermcolor', 'allow_stdout', 'help',
-                'logging', 'version', 'failfast', 'run_coverage', 'options',
-                'completions', 'completion_file', 'clear_omit',
+        if name in ['termcolor', 'notermcolor', 'allow_stdout', 'quiet_stdout',
+                'help', 'logging', 'version', 'failfast', 'run_coverage',
+                'options', 'completions', 'completion_file', 'clear_omit',
                 'no_skip_report']:
             config_getter = config.getboolean
         elif name in ['processes', 'debug', 'verbose']:

--- a/green/result.py
+++ b/green/result.py
@@ -566,7 +566,7 @@ class GreenTestResult(BaseTestResult):
     def printErrors(self):
         """
         Print a list of all tracebacks from errors and failures, as well as
-        captured stdout (even if the test passed).
+        captured stdout (even if the test passed, except with quiet_stdout option).
         """
         if self.dots:
             self.stream.writeln()
@@ -580,11 +580,12 @@ class GreenTestResult(BaseTestResult):
                     reason))
 
         # Captured output for non-failing tests
-        failing_tests = set([x[0] for x in self.all_errors])
-        for test in list(self.stdout_output):
-            if test not in failing_tests:
-                self.displayStdout(test)
-                self.displayStderr(test)
+        if not self.args.quiet_stdout:
+            failing_tests = set([x[0] for x in self.all_errors])
+            for test in list(self.stdout_output):
+                if test not in failing_tests:
+                    self.displayStdout(test)
+                    self.displayStderr(test)
 
         # Actual tracebacks and captured output for failing tests
         for (test, color_func, outcome, err) in self.all_errors:

--- a/green/test/test_result.py
+++ b/green/test/test_result.py
@@ -525,6 +525,58 @@ class TestGreenTestResult(unittest.TestCase):
         self.assertIn(output, self.stream.getvalue())
 
 
+    def test_printErrorsStdoutQuietStdoutOnSuccess(self):
+        """
+        printErrors() prints out the captured stdout
+        except when quiet_stdout is set to True
+        for successful tests
+        """
+        self.args.quiet_stdout = True
+        gtr = GreenTestResult(self.args, GreenStream(self.stream))
+        pt = MyProtoTest()
+        output = 'this is what the test should not spit out to stdout'
+        gtr.recordStdout(pt, output)
+        gtr.addSuccess(pt)
+        gtr.printErrors()
+        self.assertNotIn(output, self.stream.getvalue())
+
+
+    def test_printErrorsStdoutQuietStdoutOnError(self):
+        """
+        printErrors() prints out the captured stdout
+        except when quiet_stdout is set to True
+        for successful tests, but here we are on a
+        failling test.
+        """
+        self.args.quiet_stdout = True
+        try:
+            raise Exception
+        except:
+            err = sys.exc_info()
+        gtr = GreenTestResult(self.args, GreenStream(self.stream))
+        pt = MyProtoTest()
+        output = 'this is what the test should spit out to stdout'
+        gtr.recordStdout(pt, output)
+        gtr.addError(pt, proto_error(err))
+        gtr.printErrors()
+        self.assertIn(output, self.stream.getvalue())
+
+
+    def test_printErrorsStderrQuietStdoutOnSuccess(self):
+        """
+        printErrors() prints out the captured stdout
+        except when quiet_stdout is set to True
+        for successful tests
+        """
+        self.args.quiet_stdout = True
+        gtr = GreenTestResult(self.args, GreenStream(self.stream))
+        pt = MyProtoTest()
+        output = 'this is what the test should not spit out to stdout'
+        gtr.recordStderr(pt, output)
+        gtr.addSuccess(pt)
+        gtr.printErrors()
+        self.assertNotIn(output, self.stream.getvalue())
+
     def test_printErrorsDots(self):
         """
         printErrors() looks correct in verbose=1 (dots) mode


### PR DESCRIPTION
I am testing a Flask application which is very verbose, and I only need the added output if the test fail. So this option should only display stdout/stderr if the test is not successful.
I am not sure about the best way to integrate this with your current tests can you help me on that ? Thanks !
