### PR TITLE
Add CLI option to disable colorama

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,5 +12,6 @@ install:
       - "%PYTHON%/Scripts/pip.exe install -r requirements.txt"
 test_script:
     - "%PYTHON%/python.exe -m green.cmdline -vvv -t green"
+    - "%PYTHON%/python.exe -m green.cmdline -vvv -W green"
 platform:
     - AnyCPU

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,5 @@ install:
       - "%PYTHON%/Scripts/pip.exe install -r requirements.txt"
 test_script:
     - "%PYTHON%/python.exe -m green.cmdline -vvv -t green"
-    - "%PYTHON%/python.exe -m green.cmdline -vvv -W green"
 platform:
     - AnyCPU

--- a/cli-options.txt
+++ b/cli-options.txt
@@ -43,6 +43,7 @@ Concurrency Options:
 Format Options:
   -t, --termcolor       Force terminal colors on. Default is to autodetect.
   -T, --notermcolor     Force terminal colors off. Default is to autodetect.
+  -W, --nowindows       Disable Windows support by turning off Colorama.
 
 Output Options:
   -a, --allow-stdout    Instead of capturing the stdout and stderr and

--- a/cli-options.txt
+++ b/cli-options.txt
@@ -43,7 +43,7 @@ Concurrency Options:
 Format Options:
   -t, --termcolor       Force terminal colors on. Default is to autodetect.
   -T, --notermcolor     Force terminal colors off. Default is to autodetect.
-  -W, --nowindows       Disable Windows support by turning off Colorama.
+  -W, --disable-windows Disable Windows support by turning off Colorama.
 
 Output Options:
   -a, --allow-stdout    Instead of capturing the stdout and stderr and

--- a/green/cmdline.py
+++ b/green/cmdline.py
@@ -36,7 +36,7 @@ def main(testing=False):
     if args.debug:
         green.output.debug_level = args.debug
 
-    stream = GreenStream(sys.stdout, disable_windows=args.nowindows)
+    stream = GreenStream(sys.stdout, disable_windows=args.disable_windows)
 
     # Location of shell completion file
     if args.completion_file:

--- a/green/cmdline.py
+++ b/green/cmdline.py
@@ -36,7 +36,7 @@ def main(testing=False):
     if args.debug:
         green.output.debug_level = args.debug
 
-    stream = GreenStream(sys.stdout)
+    stream = GreenStream(sys.stdout, disable_windows=args.nowindows)
 
     # Location of shell completion file
     if args.completion_file:

--- a/green/config.py
+++ b/green/config.py
@@ -48,7 +48,7 @@ default_args             = argparse.Namespace( # pragma: no cover
         finalizer        = '',
         termcolor        = None,
         notermcolor      = None,
-        nowindows        = False,
+        disable_windows  = False,
         allow_stdout     = False,
         quiet_stdout     = False,
         no_skip_report   = False,
@@ -199,7 +199,7 @@ def parseArguments(): # pragma: no cover
         help="Force terminal colors off.  Default is to autodetect.",
         default=argparse.SUPPRESS))
     store_opt(
-        format_args.add_argument('-W', '--nowindows', action='store_true',
+        format_args.add_argument('-W', '--disable-windows', action='store_true',
         help="Disable Windows support by turning off Colorama",
         default=argparse.SUPPRESS))
 
@@ -407,7 +407,7 @@ def mergeConfig(args, testing=False): # pragma: no cover
         if name in ['termcolor', 'notermcolor', 'allow_stdout', 'quiet_stdout',
                 'help', 'logging', 'version', 'failfast', 'run_coverage',
                 'options', 'completions', 'completion_file', 'clear_omit',
-                'no_skip_report', 'nowindows']:
+                'no_skip_report', 'disable_windows']:
             config_getter = config.getboolean
         elif name in ['processes', 'debug', 'verbose']:
             config_getter = config.getint

--- a/green/config.py
+++ b/green/config.py
@@ -48,6 +48,7 @@ default_args             = argparse.Namespace( # pragma: no cover
         finalizer        = '',
         termcolor        = None,
         notermcolor      = None,
+        nowindows        = False,
         allow_stdout     = False,
         quiet_stdout     = False,
         no_skip_report   = False,
@@ -196,6 +197,10 @@ def parseArguments(): # pragma: no cover
     store_opt(
         format_args.add_argument('-T', '--notermcolor', action='store_true',
         help="Force terminal colors off.  Default is to autodetect.",
+        default=argparse.SUPPRESS))
+    store_opt(
+        format_args.add_argument('-W', '--nowindows', action='store_true',
+        help="Disable Windows support by turning off Colorama",
         default=argparse.SUPPRESS))
 
     out_args = parser.add_argument_group("Output Options")
@@ -402,7 +407,7 @@ def mergeConfig(args, testing=False): # pragma: no cover
         if name in ['termcolor', 'notermcolor', 'allow_stdout', 'quiet_stdout',
                 'help', 'logging', 'version', 'failfast', 'run_coverage',
                 'options', 'completions', 'completion_file', 'clear_omit',
-                'no_skip_report']:
+                'no_skip_report', 'nowindows']:
             config_getter = config.getboolean
         elif name in ['processes', 'debug', 'verbose']:
             config_getter = config.getint

--- a/green/output.py
+++ b/green/output.py
@@ -150,8 +150,8 @@ class GreenStream(object):
         on_appveyor = os.environ.get('APPVEYOR', False)
 
         if (override_appveyor
-                or ((on_windows and not on_appveyor)
-                    and not disable_windows)): # pragma: no cover
+                or ((on_windows and not on_appveyor))):
+                    #and not disable_windows)): # pragma: no cover
             self.stream = wrap_stream(self.stream, None, None, None, True)
         self.closed = False
 

--- a/green/output.py
+++ b/green/output.py
@@ -150,8 +150,8 @@ class GreenStream(object):
         on_appveyor = os.environ.get('APPVEYOR', False)
 
         if (override_appveyor
-                or ((on_windows and not on_appveyor))):
-                    #and not disable_windows)): # pragma: no cover
+                or ((on_windows and not on_appveyor)
+                    and not disable_windows)): # pragma: no cover
             self.stream = wrap_stream(self.stream, None, None, None, True)
         self.closed = False
 

--- a/green/output.py
+++ b/green/output.py
@@ -142,13 +142,14 @@ class GreenStream(object):
 
     indent_spaces = 2
 
-    def __init__(self, stream, override_appveyor=False):
+    def __init__(self, stream, override_appveyor=False, no_windows=False):
         self.stream = stream
         # Ironically, AppVeyor doesn't support windows win32 system calls for
         # colors, but it WILL interpret posix ansi escape codes!
         if override_appveyor or (
                 (platform.system() == 'Windows')
-                and (not os.environ.get('APPVEYOR', False))): # pragma: no cover
+                and (not os.environ.get('APPVEYOR', False))
+                and not no_windows): # pragma: no cover
             self.stream = wrap_stream(self.stream, None, None, None, True)
         self.closed = False
 

--- a/green/output.py
+++ b/green/output.py
@@ -142,14 +142,16 @@ class GreenStream(object):
 
     indent_spaces = 2
 
-    def __init__(self, stream, override_appveyor=False, no_windows=False):
+    def __init__(self, stream, override_appveyor=False, disable_windows=False):
         self.stream = stream
         # Ironically, AppVeyor doesn't support windows win32 system calls for
         # colors, but it WILL interpret posix ansi escape codes!
-        if override_appveyor or (
-                (platform.system() == 'Windows')
-                and (not os.environ.get('APPVEYOR', False))
-                and not no_windows): # pragma: no cover
+        on_windows = platform.system() == 'Windows'
+        on_appveyor = os.environ.get('APPVEYOR', False)
+
+        if (override_appveyor
+                or ((on_windows and not on_appveyor)
+                    and not disable_windows)): # pragma: no cover
             self.stream = wrap_stream(self.stream, None, None, None, True)
         self.closed = False
 

--- a/green/runner.py
+++ b/green/runner.py
@@ -61,7 +61,7 @@ def run(suite, stream, args, testing=False):
     Any args.stream passed in will be wrapped in a GreenStream
     """
     if not issubclass(GreenStream, type(stream)):
-        stream = GreenStream(stream, disable_windows=args.nowindows)
+        stream = GreenStream(stream, disable_windows=args.disable_windows)
     result = GreenTestResult(args, stream)
 
     # Note: Catching SIGINT isn't supported by Python on windows (python

--- a/green/runner.py
+++ b/green/runner.py
@@ -61,7 +61,7 @@ def run(suite, stream, args, testing=False):
     Any args.stream passed in will be wrapped in a GreenStream
     """
     if not issubclass(GreenStream, type(stream)):
-        stream = GreenStream(stream, no_windows=args.nowindows)
+        stream = GreenStream(stream, disable_windows=args.nowindows)
     result = GreenTestResult(args, stream)
 
     # Note: Catching SIGINT isn't supported by Python on windows (python

--- a/green/runner.py
+++ b/green/runner.py
@@ -61,7 +61,7 @@ def run(suite, stream, args, testing=False):
     Any args.stream passed in will be wrapped in a GreenStream
     """
     if not issubclass(GreenStream, type(stream)):
-        stream = GreenStream(stream)
+        stream = GreenStream(stream, no_windows=args.nowindows)
     result = GreenTestResult(args, stream)
 
     # Note: Catching SIGINT isn't supported by Python on windows (python

--- a/green/test/test_cmdline.py
+++ b/green/test/test_cmdline.py
@@ -133,6 +133,14 @@ class TestMain(unittest.TestCase):
         cmdline.main(testing=True)
 
 
+    def test_disableWindowsSupport(self):
+        """
+        --nowindows
+        """
+        cmdline.sys.argv = ['', '--nowindows']
+        cmdline.main(testing=True)
+
+
     def test_noCoverage(self):
         """
         The absence of coverage prompts a return code of 3

--- a/green/test/test_cmdline.py
+++ b/green/test/test_cmdline.py
@@ -135,9 +135,9 @@ class TestMain(unittest.TestCase):
 
     def test_disableWindowsSupport(self):
         """
-        --nowindows
+        --disable-windows
         """
-        cmdline.sys.argv = ['', '--nowindows']
+        cmdline.sys.argv = ['', '--disable-windows']
         cmdline.main(testing=True)
 
 

--- a/green/test/test_output.py
+++ b/green/test/test_output.py
@@ -117,7 +117,7 @@ class TestGreenStream(unittest.TestCase):
 
     def testNoWindowsTrue(self):
         """
-        nowindows=True -> ANSI color codes are present in the stream
+        nowindows=True: ANSI color codes are present in the stream
         """
         c = Colors(termcolor=True)
         s = StringIO()
@@ -131,11 +131,14 @@ class TestGreenStream(unittest.TestCase):
                      "Colorama won't strip ANSI unless runing on Windows")
     def testNoWindowsFalse(self):
         """
-        no_windows=Fals -> Colorama *will* strip ANSI codes from the stream
+        no_windows=False: Colorama strips ANSI color codes from the stream
         """
         c = Colors(termcolor=True)
         s = StringIO()
         gs = GreenStream(s, no_windows=False)
         colored_msg = c.red("a")
         gs.write(colored_msg)
-        self.assertLess(len(gs.stream.getvalue()), len(colored_msg))
+#        self.assertLess(len(gs.stream.getvalue()), len(colored_msg))
+        import colorama
+        self.assertTrue(issubclass(type(gs.stream),
+                        colorama.ansitowin32.StreamWrapper))

--- a/green/test/test_output.py
+++ b/green/test/test_output.py
@@ -115,13 +115,13 @@ class TestGreenStream(unittest.TestCase):
         self.assertEqual(s.getvalue(), msg)
 
 
-    def testNoWindowsTrue(self):
+    def testDisableWindowsTrue(self):
         """
-        nowindows=True: ANSI color codes are present in the stream
+        disable_windows=True: ANSI color codes are present in the stream
         """
         c = Colors(termcolor=True)
         s = StringIO()
-        gs = GreenStream(s, no_windows=True)
+        gs = GreenStream(s, disable_windows=True)
         msg = c.red("some colored string")
         gs.write(msg)
         self.assertEqual(len(gs.stream.getvalue()), len(msg))
@@ -129,13 +129,13 @@ class TestGreenStream(unittest.TestCase):
 
     @unittest.skipIf(platform.system() != 'Windows',
                      "Colorama won't strip ANSI unless runing on Windows")
-    def testNoWindowsFalse(self):
+    def testDisableWindowsFalse(self):
         """
-        no_windows=False: Colorama strips ANSI color codes from the stream
+        disable_windows=False: Colorama strips ANSI color codes from the stream
         """
         c = Colors(termcolor=True)
         s = StringIO()
-        gs = GreenStream(s, override_appveyor=True, no_windows=False)
+        gs = GreenStream(s, override_appveyor=True, disable_windows=False)
         colored_msg = c.red("a")
         gs.write(colored_msg)
         import colorama

--- a/green/test/test_output.py
+++ b/green/test/test_output.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+import platform
 import sys
 import unittest
 
@@ -112,3 +113,29 @@ class TestGreenStream(unittest.TestCase):
             bad_str = str(msg)
         gs.write(bad_str)
         self.assertEqual(s.getvalue(), msg)
+
+
+    def testNoWindowsTrue(self):
+        """
+        nowindows=True -> ANSI color codes are present in the stream
+        """
+        c = Colors(termcolor=True)
+        s = StringIO()
+        gs = GreenStream(s, no_windows=True)
+        msg = c.red("some colored string")
+        gs.write(msg)
+        self.assertEqual(len(gs.stream.getvalue()), len(msg))
+
+
+    @unittest.skipIf(platform.system() != 'Windows',
+                     "Colorama won't strip ANSI unless runing on Windows")
+    def testNoWindowsFalse(self):
+        """
+        no_windows=Fals -> Colorama *will* strip ANSI codes from the stream
+        """
+        c = Colors(termcolor=True)
+        s = StringIO()
+        gs = GreenStream(s, no_windows=False)
+        colored_msg = c.red("a")
+        gs.write(colored_msg)
+        self.assertLess(len(gs.stream.getvalue()), len(colored_msg))

--- a/green/test/test_output.py
+++ b/green/test/test_output.py
@@ -135,10 +135,9 @@ class TestGreenStream(unittest.TestCase):
         """
         c = Colors(termcolor=True)
         s = StringIO()
-        gs = GreenStream(s, no_windows=False)
+        gs = GreenStream(s, override_appveyor=True, no_windows=False)
         colored_msg = c.red("a")
         gs.write(colored_msg)
-#        self.assertLess(len(gs.stream.getvalue()), len(colored_msg))
         import colorama
         self.assertTrue(issubclass(type(gs.stream),
                         colorama.ansitowin32.StreamWrapper))


### PR DESCRIPTION
This PR adds a `-W` or `--nowindows` command line argument that, when present, disables windows support via Colorama.

This is useful for some CI cases, such as GitLab. See  #117.