### PR TITLE
"No tests found" now results in a failure.

### DIFF
--- a/green/result.py
+++ b/green/result.py
@@ -417,7 +417,7 @@ class GreenTestResult(BaseTestResult):
             if obj_list:
                 stats.append("{}={}".format(name, color_func(str(len(obj_list)))))
         if not stats:
-            self.stream.writeln(self.colors.passing("No Tests Found"))
+            self.stream.writeln(self.colors.failing("No Tests Found"))
         else:
             grade = self.colors.passing('OK')
             if self.errors or self.failures:
@@ -616,4 +616,8 @@ class GreenTestResult(BaseTestResult):
         """
         Tells whether or not the overall run was successful
         """
-        return len(self.all_errors) == 0
+        # fail if no tests are run.
+        if len(self.all_errors) == 0 and len(self.passing) == 0:
+            return False
+        else:
+            return len(self.all_errors) == 0

--- a/green/test/test_result.py
+++ b/green/test/test_result.py
@@ -830,6 +830,8 @@ class TestGreenTestResultAdds(unittest.TestCase):
         """
         self.args.verbose = 1
         gtr = GreenTestResult(self.args, GreenStream(self.stream))
+        self.assertEqual(gtr.wasSuccessful(), False)
+        gtr.passing.append('anything')
         self.assertEqual(gtr.wasSuccessful(), True)
         gtr.all_errors.append('anything')
         self.assertEqual(gtr.wasSuccessful(), False)

--- a/green/test/test_runner.py
+++ b/green/test/test_runner.py
@@ -194,8 +194,10 @@ class TestRun(unittest.TestCase):
         """
         When we don't find any tests, we say so.
         """
-        run(GreenTestSuite(), self.stream, self.args)
+        result = run(GreenTestSuite(), self.stream, self.args)
         self.assertIn('No Tests Found', self.stream.getvalue())
+        self.assertEqual(result.testsRun, 0)
+        self.assertEqual(result.wasSuccessful(), False)
 
     def test_failedSaysSo(self):
         """


### PR DESCRIPTION
Fixes #123.

This changes the return value and text coloring when no tests are found.

I wasn't able to figure out where any unit tests for this should go (I have limited time today), so if you could let me know where they should go, I'll try writing some tomorrow.