### PR TITLE
Fix AttributeError when running non-test

### DIFF
--- a/green/process.py
+++ b/green/process.py
@@ -329,5 +329,6 @@ def poolRunner(target, queue, coverage_number=None, omit_patterns=[]): # pragma:
         result.startTest(t)
         result.addError(t, err)
         result.stopTest(t)
+        queue.put(result)
 
     cleanup()


### PR DESCRIPTION
The `run` function in [runner.py](https://github.com/CleanCut/green/blob/7f4655a/green/runner.py#L117) assumes a specific order of messages from the queue. If the test loader in [`poolRunner`](https://github.com/CleanCut/green/blob/7f4655a/green/process.py#L234) [got an unrunnable object](https://github.com/CleanCut/green/blob/7f4655a/green/process.py#L319), it would attempt to report it, but would never actually put the result in the queue, so the run function would fail because it assumed it would get a result instead of the sentinel `None` from the `cleanup` function.

I think this is because of the changes introduced in [efb54c0](https://github.com/CleanCut/green/commit/efb54c065422d60303b126d694c52bfb8), which moved from putting the result object into the queue in the `stop_callback` of the `ProtoTestResult` to the `finalize_callback` with the new `finalize` method which would only be called from the test's `run` method. These changes correctly put the result object into the queue when the test was not able to run, but did not account for the need in this abnormal case.