### PR TITLE
Remove duplicate attempt to put test in queue

### DIFF
--- a/green/process.py
+++ b/green/process.py
@@ -288,7 +288,6 @@ def poolRunner(target, queue, coverage_number=None, omit_patterns=[]): # pragma:
         result.startTest(t)
         result.addError(t, err)
         result.stopTest(t)
-        queue.put(t)
         queue.put(result)
         cleanup()
         return


### PR DESCRIPTION
Added in [efb54c0](https://github.com/CleanCut/green/commit/efb54c065422d60303b126d694c52bfb8). The test is already put into the queue in the `start_callback`, which filters out this second attempt with the set, but shouldn't need to.