### PR TITLE
Travis Matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ install:
 script:
   - "make test"
 after_success: "if [ $TRAVIS_OS_NAME == linux ] ; then coveralls ; fi"
+cache: pip
 matrix:
+    fast_finish: true
     include:
         - os: osx
           osx_image: xcode7.3
@@ -43,8 +45,19 @@ matrix:
           python: 3.5
           language: python
         - os: linux
+          python: '3.6-dev'
+          language: python
+        - os: linux
+          python: 'nightly'
+          language: python
+        - os: linux
           python: pypy
           language: python
         - os: linux
           python: pypy3
           language: python
+
+    allow_failures:
+        - python: '3.6-dev'
+        - python: "nightly"
+        - os: "osx"

--- a/test_versions
+++ b/test_versions
@@ -19,11 +19,18 @@ if [ "${PYTHON_VERSIONS}" == "" ] ; then
     PYTHON_VERSIONS="default"
 fi
 
+if [[ "${PYTHON_VERSIONS}" == *-dev ]] ; then
+    PYTHON_VERSIONS="${PYTHON_VERSIONS::-4}"
+fi
+
 echo "Identified python versions: `echo ${PYTHON_VERSIONS} | tr '\n' ' '`"
 
 # Make sure each of the pythons has the necessary requirements installed
 for PYTHON_VERSION in ${PYTHON_VERSIONS} ; do
     if [ "${PYTHON_VERSION}" == "default" ] ; then
+        PYTHON_VERSION=""
+    fi
+    if [ "${PYTHON_VERSION}" == "nightly" ] ; then
         PYTHON_VERSION=""
     fi
     if [ "${PYTHON_VERSION}" == "pypy" ] ; then


### PR DESCRIPTION
This expand the Travis test matrix to:
- test Python 3.6 betas and 'nightly' (currently early alpha builts to Python 3.7) as an allowed failure
- move the OSX builds to an 'allowed failure'
