### PR TITLE
[FEATURE] Added --green-verbosity flag for Django test runner

### DIFF
--- a/green/djangorunner.py
+++ b/green/djangorunner.py
@@ -73,7 +73,7 @@ try:
 
     class DjangoRunner(DiscoverRunner):
 
-        def __init__(self, verbose=1, **kwargs):
+        def __init__(self, verbose=-1, **kwargs):
 
             super(DjangoRunner, self).__init__()
             self.verbose = verbose
@@ -81,7 +81,7 @@ try:
         @classmethod
         def add_arguments(cls, parser):
             parser.add_argument ('--green-verbosity',
-                                    action='store', dest='verbose', default=1,
+                                    action='store', dest='verbose', default=-1,
                                     help="""Used to select a verbosity level for the tests.
                                     Values can range from 1-3 and overrides the configuration
                                     provided in the .green file""")
@@ -111,7 +111,8 @@ try:
                 test_labels = ['.']
 
             args = mergeConfig(Namespace())
-            args.verbose = int(self.verbose)
+            if int(self.verbose) in (1,2,3):
+                args.verbose = int(self.verbose)
             args.targets = test_labels
             stream = GreenStream(sys.stdout)
             suite = loadTargets(args.targets)

--- a/green/djangorunner.py
+++ b/green/djangorunner.py
@@ -75,7 +75,7 @@ try:
 
         def __init__(self, verbose=1, **kwargs):
 
-            super ().__init__ ()
+            super(DjangoRunner, self).__init__()
             self.verbose = verbose
 
         @classmethod

--- a/green/djangorunner.py
+++ b/green/djangorunner.py
@@ -73,6 +73,19 @@ try:
 
     class DjangoRunner(DiscoverRunner):
 
+        def __init__(self, verbose=1, **kwargs):
+
+            super ().__init__ ()
+            self.verbose = verbose
+
+        @classmethod
+        def add_arguments(cls, parser):
+            parser.add_argument ('--green-verbosity',
+                                    action='store', dest='verbose', default=1,
+                                    help="""Used to select a verbosity level for the tests.
+                                    Values can range from 1-3 and overrides the configuration
+                                    provided in the .green file""")
+
         def run_tests(self, test_labels, extra_tests=None, **kwargs):
             """
             Run the unit tests for all the test labels in the provided list.
@@ -98,6 +111,7 @@ try:
                 test_labels = ['.']
 
             args = mergeConfig(Namespace())
+            args.verbose = int(self.verbose)
             args.targets = test_labels
             stream = GreenStream(sys.stdout)
             suite = loadTargets(args.targets)


### PR DESCRIPTION
  * Makes it possible to pass verbosity for Django tests using
    command line arguments to `python manage.py test`

  * The flag is optional and defaults to `verbose=1`

  * The passed value of verbosity overrides value provided in the
    .green file or any other configuration file

> Sample usage
> `python manage.py test --green-verbosity 2`