### PR TITLE
Implement GreenTestLoader and load_test protocol

### DIFF
--- a/green/cmdline.py
+++ b/green/cmdline.py
@@ -26,7 +26,7 @@ def main(testing=False):
     sys.argv = sys.argv[:1]
 
     # Set up our various main objects
-    from green.loader import GreenTestLoader
+    from green.loader import GreenTestLoader, getCompletions
     from green.runner import run
     from green.output import GreenStream, debug
     import green.output
@@ -45,7 +45,7 @@ def main(testing=False):
 
     # Argument-completion for bash and zsh (for test-target completion)
     if args.completions:
-        print(GreenTestLoader.getCompletions(args.targets))
+        print(getCompletions(args.targets))
         return 0
 
     # Option-completion for bash and zsh

--- a/green/cmdline.py
+++ b/green/cmdline.py
@@ -26,7 +26,7 @@ def main(testing=False):
     sys.argv = sys.argv[:1]
 
     # Set up our various main objects
-    from green.loader import loadTargets
+    from green.loader import GreenTestLoader
     from green.runner import run
     from green.output import GreenStream, debug
     import green.output
@@ -45,8 +45,7 @@ def main(testing=False):
 
     # Argument-completion for bash and zsh (for test-target completion)
     if args.completions:
-        from green.loader import getCompletions
-        print(getCompletions(args.targets))
+        print(GreenTestLoader.getCompletions(args.targets))
         return 0
 
     # Option-completion for bash and zsh
@@ -63,7 +62,9 @@ def main(testing=False):
     if testing:
         test_suite = None
     else:  # pragma: no cover
-        test_suite = loadTargets(args.targets, file_pattern=args.file_pattern)
+        loader = GreenTestLoader()
+        test_suite = loader.loadTargets(args.targets,
+                                        file_pattern=args.file_pattern)
 
     # We didn't even load 0 tests...
     if not test_suite:

--- a/green/djangorunner.py
+++ b/green/djangorunner.py
@@ -14,7 +14,7 @@ import os
 import sys
 
 from green.config import mergeConfig
-from green.loader import loadTargets
+from green.loader import GreenTestLoader
 from green.output import GreenStream
 from green.runner import run
 from green.suite import GreenTestSuite
@@ -77,6 +77,7 @@ try:
 
             super(DjangoRunner, self).__init__()
             self.verbosity = verbosity
+            self.loader = GreenTestLoader()
 
         @classmethod
         def add_arguments(cls, parser):
@@ -116,7 +117,7 @@ try:
                 args.verbosity = self.verbosity
             args.targets = test_labels
             stream = GreenStream(sys.stdout)
-            suite = loadTargets(args.targets)
+            suite = self.loader.loadTargets(args.targets)
             if not suite:
                 suite = GreenTestSuite()
             result = run(suite, stream, args)

--- a/green/loader.py
+++ b/green/loader.py
@@ -18,406 +18,221 @@ python_file_pattern = re.compile(r'^[_a-z]\w*?\.py$', re.IGNORECASE)
 python_dir_pattern  = re.compile(r'^[_a-z]\w*?$', re.IGNORECASE)
 
 
-def toProtoTestList(suite, test_list=None, doing_completions=False):
-    """
-    Take a test suite and turn it into a list of ProtoTests.
-
-    This function is recursive.  Pass it a suite, and it will re-call itself
-    with smaller parts of the suite.
-    """
-    if test_list is None:
-        test_list = []
-    # Python's lousy handling of module import failures during loader discovery
-    # makes this crazy special case necessary.  See _make_failed_import_test in
-    # the source code for unittest.loader
-    if suite.__class__.__name__ == 'ModuleImportFailure':
-        if doing_completions:
-            return test_list
-        exception_method = str(suite).split()[0]
-        getattr(suite, exception_method)()
-    # On to the real stuff
-    if issubclass(type(suite), unittest.TestCase):
-        # Skip actual blank TestCase objects that twisted inserts
-        if str(type(suite)) != "<class 'twisted.trial.unittest.TestCase'>":
-            test_list.append(proto_test(suite))
-    else:
-        for i in suite:
-            toProtoTestList(i, test_list, doing_completions)
-    return test_list
 
 
-def toParallelTargets(suite, targets):
-    """
-    Produce a list of targets which should be tested in parallel.
+class GreenTestLoader(unittest.TestLoader):
 
-    For the most part this will be a list of test modules.  The exception is
-    when a dotted name representing something more granular than a module was
-    input (like an individal test case or test method)
-    """
-    targets = filter(lambda x: x != '.', targets)
-    # First, convert the suite to a proto test list - proto tests nicely parse
-    # things like the fully dotted name of the test and the finest-grained
-    # module it belongs to, which simplifies our job.
-    proto_test_list = toProtoTestList(suite)
-    # Extract a list of the modules that all of the discovered tests are in
-    modules = set([x.module for x in proto_test_list])
-    # Get the list of user-specified targets that are NOT modules
-    non_module_targets = []
-    for target in targets:
-        if not list(filter(None, [target in x for x in modules])):
-            non_module_targets.append(target)
-    # Main loop -- iterating through all loaded test methods
-    parallel_targets = []
-    for test in proto_test_list:
-        found = False
-        for target in non_module_targets:
-            # target is a dotted name of either a test case or test method here
-            # test.dotted name is always a dotted name of a method
-            if (target in test.dotted_name):
-                if target not in parallel_targets:
-                    # Explicitly specified targets get their own entry to run
-                    # parallel to everything else
-                    parallel_targets.append(target)
-                found = True
-                break
-        if found:
-            continue
-        # This test does not appear to be part of a specified target, so its
-        # entire module must have been discovered, so just add the whole module
-        # to the list if we haven't already.
-        if test.module not in parallel_targets:
-            parallel_targets.append(test.module)
-    return parallel_targets
+    suiteClass = GreenTestSuite
 
+    @classmethod
+    def toProtoTestList(cls, suite, test_list=None, doing_completions=False):
+        """
+        Take a test suite and turn it into a list of ProtoTests.
 
-def getCompletions(target):
-        # This option expects 0 or 1 targets
-        if type(target) == list:
-            target = target[0]
-        if target == '.':
-            target = ''
+        This function is recursive.  Pass it a suite, and it will re-call itself
+        with smaller parts of the suite.
+        """
+        if test_list is None:
+            test_list = []
+        # Python's lousy handling of module import failures during loader discovery
+        # makes this crazy special case necessary.  See _make_failed_import_test in
+        # the source code for unittest.loader
+        if suite.__class__.__name__ == 'ModuleImportFailure':
+            if doing_completions:
+                return test_list
+            exception_method = str(suite).split()[0]
+            getattr(suite, exception_method)()
+        # On to the real stuff
+        if issubclass(type(suite), unittest.TestCase):
+            # Skip actual blank TestCase objects that twisted inserts
+            if str(type(suite)) != "<class 'twisted.trial.unittest.TestCase'>":
+                test_list.append(proto_test(suite))
+        else:
+            for i in suite:
+                cls.toProtoTestList(i, test_list, doing_completions)
+        return test_list
 
-        # Discover tests and load them into a suite
+    @classmethod
+    def toParallelTargets(cls, suite, targets):
+        """
+        Produce a list of targets which should be tested in parallel.
 
-        # First try the completion as-is.  It might be at a valid spot.
-        test_suite = loadTargets(target)
-        if not test_suite:
-            # Next, try stripping to the previous '.'
-            last_dot_idx = target.rfind('.')
-            to_complete = None
-            if last_dot_idx > 0:
-                to_complete = target[:last_dot_idx]
-            elif len(target):
-                # Oops, there was no previous '.' -- try filesystem matches
-                to_complete = glob.glob(target + '*')
-            if not to_complete:
-                to_complete = '.'
-            test_suite = loadTargets(to_complete)
+        For the most part this will be a list of test modules.  The exception is
+        when a dotted name representing something more granular than a module was
+        input (like an individal test case or test method)
+        """
+        targets = filter(lambda x: x != '.', targets)
+        # First, convert the suite to a proto test list - proto tests nicely parse
+        # things like the fully dotted name of the test and the finest-grained
+        # module it belongs to, which simplifies our job.
+        proto_test_list = cls.toProtoTestList(suite)
+        # Extract a list of the modules that all of the discovered tests are in
+        modules = set([x.module for x in proto_test_list])
+        # Get the list of user-specified targets that are NOT modules
+        non_module_targets = []
+        for target in targets:
+            if not list(filter(None, [target in x for x in modules])):
+                non_module_targets.append(target)
+        # Main loop -- iterating through all loaded test methods
+        parallel_targets = []
+        for test in proto_test_list:
+            found = False
+            for target in non_module_targets:
+                # target is a dotted name of either a test case or test method here
+                # test.dotted name is always a dotted name of a method
+                if (target in test.dotted_name):
+                    if target not in parallel_targets:
+                        # Explicitly specified targets get their own entry to run
+                        # parallel to everything else
+                        parallel_targets.append(target)
+                    found = True
+                    break
+            if found:
+                continue
+            # This test does not appear to be part of a specified target, so its
+            # entire module must have been discovered, so just add the whole module
+            # to the list if we haven't already.
+            if test.module not in parallel_targets:
+                parallel_targets.append(test.module)
+        return parallel_targets
 
-        # Reduce the suite to a list of relevant dotted names
+    @classmethod
+    def getCompletions(cls, target):
+            # This option expects 0 or 1 targets
+            if type(target) == list:
+                target = target[0]
+            if target == '.':
+                target = ''
 
-        dotted_names = set()
-        if test_suite:
-            for dotted_name in [x.dotted_name for x in toProtoTestList(test_suite, doing_completions=True)]:
-                if dotted_name.startswith(target):
-                    dotted_names.add(dotted_name)
-            # We have the fully dotted test names.  Now add the intermediate
-            # completions.  bash and zsh will filter out the intermediates that
-            # don't match.
-            for dotted_name in list(dotted_names):
-                while True:
-                    idx = dotted_name.rfind('.')
-                    if idx == -1:
-                        break
-                    dotted_name = dotted_name[:idx]
+            # Discover tests and load them into a suite
+
+            # First try the completion as-is.  It might be at a valid spot.
+            loader = cls()
+            test_suite = loader.loadTargets(target)
+            if not test_suite:
+                # Next, try stripping to the previous '.'
+                last_dot_idx = target.rfind('.')
+                to_complete = None
+                if last_dot_idx > 0:
+                    to_complete = target[:last_dot_idx]
+                elif len(target):
+                    # Oops, there was no previous '.' -- try filesystem matches
+                    to_complete = glob.glob(target + '*')
+                if not to_complete:
+                    to_complete = '.'
+                test_suite = loader.loadTargets(to_complete)
+
+            # Reduce the suite to a list of relevant dotted names
+            dotted_names = set()
+            if test_suite:
+                for dotted_name in [x.dotted_name for x in cls.toProtoTestList(test_suite, doing_completions=True)]:
                     if dotted_name.startswith(target):
                         dotted_names.add(dotted_name)
-                    else:
-                        break
-        return('\n'.join(sorted(list(dotted_names))))
+                # We have the fully dotted test names.  Now add the intermediate
+                # completions.  bash and zsh will filter out the intermediates that
+                # don't match.
+                for dotted_name in list(dotted_names):
+                    while True:
+                        idx = dotted_name.rfind('.')
+                        if idx == -1:
+                            break
+                        dotted_name = dotted_name[:idx]
+                        if dotted_name.startswith(target):
+                            dotted_names.add(dotted_name)
+                        else:
+                            break
+            return('\n'.join(sorted(list(dotted_names))))
 
+    @staticmethod
+    def isPackage(file_path):
+        """
+        Determine whether or not a given path is a (sub)package or not.
+        """
+        return (os.path.isdir(file_path) and
+                os.path.isfile(os.path.join(file_path, '__init__.py')))
 
-def isPackage(file_path):
-    """
-    Determine whether or not a given path is a (sub)package or not.
-    """
-    return (os.path.isdir(file_path) and
-            os.path.isfile(os.path.join(file_path, '__init__.py')))
+    @classmethod
+    def findDottedModuleAndParentDir(cls, file_path):
+        """
+        I return a tuple (dotted_module, parent_dir) where dotted_module is the
+        full dotted name of the module with respect to the package it is in, and
+        parent_dir is the absolute path to the parent directory of the package.
 
+        If the python file is not part of a package, I return (None, None).
 
-def findDottedModuleAndParentDir(file_path):
-    """
-    I return a tuple (dotted_module, parent_dir) where dotted_module is the
-    full dotted name of the module with respect to the package it is in, and
-    parent_dir is the absolute path to the parent directory of the package.
+        For for filepath /a/b/c/d.py where b is the package, ('b.c.d', '/a') would
+        be returned.
+        """
+        if not os.path.isfile(file_path):
+            raise ValueError("'{}' is not a file.".format(file_path))
+        parent_dir = os.path.dirname(os.path.abspath(file_path))
+        dotted_module = os.path.basename(file_path).replace('.py', '')
+        while cls.isPackage(parent_dir):
+            dotted_module = os.path.basename(parent_dir) + '.' + dotted_module
+            parent_dir = os.path.dirname(parent_dir)
+        debug("Dotted module: {} -> {}".format(
+            parent_dir, dotted_module), 2)
+        return (dotted_module, parent_dir)
 
-    If the python file is not part of a package, I return (None, None).
+    @staticmethod
+    def isTestCaseDisabled(test_case_class, method_name):
+        """
+        I check to see if a method on a TestCase has been disabled via nose's
+        convention for disabling a TestCase.  This makes it so that users can mix
+        nose's parameterized tests with green as a runner.
+        """
+        test_method = getattr(test_case_class, method_name)
+        return getattr(test_method, "__test__", 'not nose') is False
 
-    For for filepath /a/b/c/d.py where b is the package, ('b.c.d', '/a') would
-    be returned.
-    """
-    if not os.path.isfile(file_path):
-        raise ValueError("'{}' is not a file.".format(file_path))
-    parent_dir = os.path.dirname(os.path.abspath(file_path))
-    dotted_module = os.path.basename(file_path).replace('.py', '')
-    while isPackage(parent_dir):
-        dotted_module = os.path.basename(parent_dir) + '.' + dotted_module
-        parent_dir = os.path.dirname(parent_dir)
-    debug("Dotted module: {} -> {}".format(
-        parent_dir, dotted_module), 2)
-    return (dotted_module, parent_dir)
+    def loadTestsFromTestCase(self, testCaseClass):
+        debug("Examining test case {}".format(testCaseClass.__name__), 3)
 
+        def filter_test_methods(attrname):
+            return attrname.startswith(self.testMethodPrefix) \
+               and callable(getattr(testCaseClass, attrname)) \
+               and not self.isTestCaseDisabled(testCaseClass, attrname)
 
-def isTestCaseDisabled(test_case_class, method_name):
-    """
-    I check to see if a method on a TestCase has been disabled via nose's
-    convention for disabling a TestCase.  This makes it so that users can mix
-    nose's parameterized tests with green as a runner.
-    """
-    test_method = getattr(test_case_class, method_name)
-    return getattr(test_method, "__test__", 'not nose') is False
+        test_case_names = list(filter(filter_test_methods, dir(testCaseClass)))
+        debug("Test case names: {}".format(test_case_names))
 
+        # Use default unittest.TestSuite sorting method if not overriden
+        test_case_names.sort(key=functools.cmp_to_key(self.sortTestMethodsUsing))
 
-def loadFromTestCase(test_case_class):
-    debug("Examining test case {}".format(test_case_class.__name__), 3)
-    test_case_names = list(filter(
-        lambda attrname: (attrname.startswith('test') and
-                          callable(getattr(test_case_class, attrname)) and
-                          not isTestCaseDisabled(test_case_class, attrname)),
-        dir(test_case_class)))
-    debug("Test case names: {}".format(test_case_names))
-    test_case_names.sort(
-            key=functools.cmp_to_key(lambda x, y: (x > y) - (x < y)))
-    if not test_case_names and hasattr(test_case_class, 'runTest'):
-        test_case_names = ['runTest']
-    return GreenTestSuite(map(test_case_class, test_case_names))
+        if not test_case_names and hasattr(testCaseClass, 'runTest'):
+            test_case_names = ['runTest']
+        return self.suiteClass(map(testCaseClass, test_case_names))
 
-
-def loadFromModule(module):
-    debug("Examining module {} for test cases".format(module.__name__), 2)
-    test_cases = []
-    for item in dir(module):
-        obj = getattr(module, item)
-        if isinstance(obj, type) and issubclass(obj, unittest.case.TestCase):
-            test_cases.append(loadFromTestCase(obj))
-    return GreenTestSuite(test_cases)
-
-
-def loadFromModuleFilename(filename):
-    dotted_module, parent_dir = findDottedModuleAndParentDir(filename)
-    # Adding the parent path of the module to the start of sys.path is
-    # the closest we can get to an absolute import in Python that I can
-    # find.
-    sys.path.insert(0, parent_dir)
-    try:
-        __import__(dotted_module)
-        loaded_module = sys.modules[dotted_module]
-        debug("Imported {}".format(dotted_module), 2)
-    except unittest.case.SkipTest as e:
-        # TODO: #25 - Right now this mimics the behavior in unittest.  Lets
-        # refactor it and simplify it after we make sure it works.
-        # This is a cause of the traceback mangling I observed.
-        reason = str(e)
-
-        @unittest.case.skip(reason)
-        def testSkipped(self):
-            pass  # pragma: no cover
-
-        TestClass = type(
-                str("ModuleSkipped"),
-                (unittest.case.TestCase,),
-                {filename: testSkipped})
-        return GreenTestSuite((TestClass(filename),))
-    except:
-        # TODO: #25 - Right now this mimics the behavior in unittest.  Lets
-        # refactor it and simplify it after we make sure it works.
-        # This is a cause of the traceback mangling I observed.
-        message = ('Failed to import {} computed from filename {}\n{}').format(
-                       dotted_module, filename, traceback.format_exc())
-
-        def testFailure(self):
-            raise ImportError(message)
-
-        TestClass = type(
-                str("ModuleImportFailure"),
-                (unittest.case.TestCase,),
-                {filename: testFailure})
-        return GreenTestSuite((TestClass(filename),))
-    finally:
-        # This gets called before return statements in except clauses
-        # actually return.  Yay!
-        sys.path.pop(0)
-
-    # --- Find the tests inside the loaded module ---
-    return loadFromModule(loaded_module)
-
-
-def discover(current_path, file_pattern='test*.py'):
-    """
-    I take a path to a directory and discover all the tests inside files
-    matching file_pattern.
-
-    If path is not a readable directory, I raise an ImportError.
-
-    If I don't find anything, I return None.  Otherwise I return a
-    GreenTestSuite
-    """
-    current_abspath = os.path.abspath(current_path)
-    if not os.path.isdir(current_abspath):
-        raise ImportError(
-                "'{}' is not a directory".format(str(current_path)))
-    suite = GreenTestSuite()
-    for file_or_dir_name in sorted(os.listdir(current_abspath)):
-        path = os.path.join(current_abspath, file_or_dir_name)
-        # Recurse into directories, attempting to skip virtual environments
-        if os.path.isdir(path) and not os.path.isfile(os.path.join(path, 'bin', 'activate')):
-            # Don't follow symlinks
-            if os.path.islink(path):
-                continue
-            # Don't recurse into directories that couldn't be a package name
-            if not python_dir_pattern.match(file_or_dir_name):
-                continue
-            subdir_suite = discover(path, file_pattern=file_pattern)
-            if subdir_suite:
-                suite.addTest(subdir_suite)
-
-        elif os.path.isfile(path):
-            # Skip irrelevant files
-            if not python_file_pattern.match(file_or_dir_name):
-                continue
-            if not fnmatch(file_or_dir_name, file_pattern):
-                continue
-
-            # Try loading the file as a module
-            module_suite = loadFromModuleFilename(path)
-            if module_suite:
-                suite.addTest(module_suite)
-
-    return ((suite.countTestCases() and suite) or None)
-
-
-def loadTargets(targets, file_pattern='test*.py'):
-    # If a string was passed in, put it into a list.
-    if type(targets) != list:
-        targets = [targets]
-
-    # Make sure there are no duplicate entries, preserving order
-    target_dict = OrderedDict()
-    for target in targets:
-        target_dict[target] = True
-    targets = target_dict.keys()
-
-    suites = []
-    for target in targets:
-        suite = loadTarget(target, file_pattern)
-        if not suite:
-            debug("Found 0 tests for target '{}'".format(target))
-            continue
-        suites.append(suite)
-        num_tests = suite.countTestCases()
-        debug("Found {} test{} for target '{}'".format(
-            num_tests, '' if (num_tests == 1) else 's', target))
-
-    if suites:
-        return GreenTestSuite(suites)
-    else:
-        return None
-
-
-def loadTarget(target, file_pattern='test*.py'):
-    """
-    """
-    debug("Attempting to load target '{}' with file_pattern '{}'".format(
-        target, file_pattern))
-    loader = unittest.TestLoader()
-    loader.suiteClass = GreenTestSuite
-
-    # For a test loader, we want to always the current working directory to be
-    # the first item in sys.path, just like when a python interpreter is loaded
-    # interactively.  See also
-    # https://docs.python.org/3.4/library/sys.html#sys.path
-    if sys.path[0] != '':
-        sys.path.insert(0, '')
-
-    # DIRECTORY VARIATIONS - These will discover all tests in a directory
-    # structure, whether or not they are accessible by the root package.
-
-    # some/real/dir
-    bare_dir = target
-    # some.real.dir
-    if ('.' in target) and (len(target) > 1):
-        dot_dir = target[0] + target[1:].replace('.', os.sep)
-    else:
-        dot_dir = None
-    # pyzmq.tests  (Package (=dir) in PYTHONPATH, including installed ones)
-    pkg_in_path_dir = None
-    if target and (target[0] != '.'):
+    def loadFromModuleFilename(self, filename):
+        dotted_module, parent_dir = self.findDottedModuleAndParentDir(filename)
+        # Adding the parent path of the module to the start of sys.path is
+        # the closest we can get to an absolute import in Python that I can
+        # find.
+        sys.path.insert(0, parent_dir)
         try:
-            filename = importlib.import_module(target).__file__
-            if '__init__.py' in filename:
-                pkg_in_path_dir = os.path.dirname(filename)
-        except:
-            pkg_in_path_dir = None
-
-    # => DISCOVER DIRS
-    tests = None
-    for candidate in [bare_dir, dot_dir, pkg_in_path_dir]:
-        if (candidate is None) or (not os.path.isdir(candidate)):
-            continue
-        tests = discover(candidate, file_pattern=file_pattern)
-        if tests and tests.countTestCases():
-            debug("Load method: DISCOVER - {}".format(candidate))
-            return tests
-
-    # DOTTED OBJECT - These will discover a specific object if it is
-    # globally importable or importable from the current working directory.
-    # Examples: pkg, pkg.module, pkg.module.class, pkg.module.class.func
-    tests = None
-    if target and (target[0] != '.'):  # We don't handle relative dot objects
-        try:
-            tests = loader.loadTestsFromName(target)
-            for index, test in enumerate(tests):
-                if test.__class__.__name__ == '_FailedTest':  # pragma: no cover
-                    del(tests._tests[index])
-
-        except Exception as e:
-            debug("IGNORED exception: {}".format(e))
-        if tests and tests.countTestCases():
-            debug("Load method: DOTTED OBJECT - {}".format(target))
-            return tests
-
-    # FILE VARIATIONS - These will import a specific file and any tests
-    # accessible from its scope.
-
-    # some/file.py
-    bare_file = target
-    # some/file
-    pyless_file = target + '.py'
-    for candidate in [bare_file, pyless_file]:
-        if (candidate is None) or (not os.path.isfile(candidate)):
-            continue
-        need_cleanup = False
-        cwd = os.getcwd()
-        if cwd != sys.path[0]:
-            need_cleanup = True
-            sys.path.insert(0, cwd)
-        try:
-            dotted_path = target.replace('.py', '').replace(os.sep, '.')
-            tests = loader.loadTestsFromName(dotted_path)
-        except:  # Any exception could occur here
+            __import__(dotted_module)
+            loaded_module = sys.modules[dotted_module]
+            debug("Imported {}".format(dotted_module), 2)
+        except unittest.case.SkipTest as e:
             # TODO: #25 - Right now this mimics the behavior in unittest.  Lets
             # refactor it and simplify it after we make sure it works.
             # This is a cause of the traceback mangling I observed.
-            try:
-                message = ('Failed to import "{}":\n{}').format(
-                               dotted_path, traceback.format_exc())
-            # If the line that caused the exception has unicode literals in it
-            # anywhere, then python 2.7 will crash on traceback.format_exc().
-            # Python 3 is ok.
-            except UnicodeDecodeError:  # pragma: no cover
-                message = ('Failed to import "{}", and the import traceback '
-                           'has a unicode decode error, so I can\'t display '
-                           'it.'.format(dotted_path))
+            reason = str(e)
+
+            @unittest.case.skip(reason)
+            def testSkipped(self):
+                pass  # pragma: no cover
+
+            TestClass = type(
+                    str("ModuleSkipped"),
+                    (unittest.case.TestCase,),
+                    {filename: testSkipped})
+            return self.suiteClass((TestClass(filename),))
+        except:
+            # TODO: #25 - Right now this mimics the behavior in unittest.  Lets
+            # refactor it and simplify it after we make sure it works.
+            # This is a cause of the traceback mangling I observed.
+            message = ('Failed to import {} computed from filename {}\n{}').format(
+                           dotted_module, filename, traceback.format_exc())
 
             def testFailure(self):
                 raise ImportError(message)
@@ -425,12 +240,191 @@ def loadTarget(target, file_pattern='test*.py'):
             TestClass = type(
                     str("ModuleImportFailure"),
                     (unittest.case.TestCase,),
-                    {dotted_path: testFailure})
-            return GreenTestSuite((TestClass(dotted_path),))
-        if need_cleanup:
-            sys.path.remove(cwd)
-        if tests and tests.countTestCases():
-            debug("Load method: FILE - {}".format(candidate))
-            return tests
+                    {filename: testFailure})
+            return self.suiteClass((TestClass(filename),))
+        finally:
+            # This gets called before return statements in except clauses
+            # actually return.  Yay!
+            sys.path.pop(0)
 
-    return None
+        # --- Find the tests inside the loaded module ---
+        return self.loadTestsFromModule(loaded_module)
+
+
+    def discover(self, current_path, file_pattern='test*.py', top_level_dir=None):
+        """
+        I take a path to a directory and discover all the tests inside files
+        matching file_pattern.
+
+        If path is not a readable directory, I raise an ImportError.
+
+        If I don't find anything, I return None.  Otherwise I return a
+        GreenTestSuite
+        """
+        current_abspath = os.path.abspath(current_path)
+        if not os.path.isdir(current_abspath):
+            raise ImportError(
+                    "'{}' is not a directory".format(str(current_path)))
+        suite = GreenTestSuite()
+        for file_or_dir_name in sorted(os.listdir(current_abspath)):
+            path = os.path.join(current_abspath, file_or_dir_name)
+            # Recurse into directories, attempting to skip virtual environments
+            if os.path.isdir(path) and not os.path.isfile(os.path.join(path, 'bin', 'activate')):
+                # Don't follow symlinks
+                if os.path.islink(path):
+                    continue
+                # Don't recurse into directories that couldn't be a package name
+                if not python_dir_pattern.match(file_or_dir_name):
+                    continue
+
+                subdir_suite = self.discover(path, file_pattern=file_pattern,
+                                             top_level_dir=top_level_dir or current_path)
+                if subdir_suite:
+                    suite.addTest(subdir_suite)
+
+            elif os.path.isfile(path):
+                # Skip irrelevant files
+                if not python_file_pattern.match(file_or_dir_name):
+                    continue
+                if not fnmatch(file_or_dir_name, file_pattern):
+                    continue
+
+                # Try loading the file as a module
+                module_suite = self.loadFromModuleFilename(path)
+                if module_suite:
+                    suite.addTest(module_suite)
+
+        return suite if suite.countTestCases() else None
+
+    def loadTargets(self, targets, file_pattern='test*.py'):
+        # If a string was passed in, put it into a list.
+        if type(targets) != list:
+            targets = [targets]
+
+        # Make sure there are no duplicate entries, preserving order
+        target_dict = OrderedDict()
+        for target in targets:
+            target_dict[target] = True
+        targets = target_dict.keys()
+
+        suites = []
+        for target in targets:
+            suite = self.loadTarget(target, file_pattern)
+            if not suite:
+                debug("Found 0 tests for target '{}'".format(target))
+                continue
+            suites.append(suite)
+            num_tests = suite.countTestCases()
+            debug("Found {} test{} for target '{}'".format(
+                num_tests, '' if (num_tests == 1) else 's', target))
+
+        return GreenTestSuite(suites) if suites else None
+
+    def loadTarget(self, target, file_pattern='test*.py'):
+        """
+        """
+        debug("Attempting to load target '{}' with file_pattern '{}'".format(
+            target, file_pattern))
+
+        # For a test loader, we want to always the current working directory to be
+        # the first item in sys.path, just like when a python interpreter is loaded
+        # interactively.  See also
+        # https://docs.python.org/3.4/library/sys.html#sys.path
+        if sys.path[0] != '':
+            sys.path.insert(0, '')
+
+        # DIRECTORY VARIATIONS - These will discover all tests in a directory
+        # structure, whether or not they are accessible by the root package.
+
+        # some/real/dir
+        bare_dir = target
+        # some.real.dir
+        if ('.' in target) and (len(target) > 1):
+            dot_dir = target[0] + target[1:].replace('.', os.sep)
+        else:
+            dot_dir = None
+        # pyzmq.tests  (Package (=dir) in PYTHONPATH, including installed ones)
+        pkg_in_path_dir = None
+        if target and (target[0] != '.'):
+            try:
+                filename = importlib.import_module(target).__file__
+                if '__init__.py' in filename:
+                    pkg_in_path_dir = os.path.dirname(filename)
+            except:
+                pkg_in_path_dir = None
+
+        # => DISCOVER DIRS
+        tests = None
+        for candidate in [bare_dir, dot_dir, pkg_in_path_dir]:
+            if (candidate is None) or (not os.path.isdir(candidate)):
+                continue
+            tests = self.discover(candidate, file_pattern=file_pattern)
+            if tests and tests.countTestCases():
+                debug("Load method: DISCOVER - {}".format(candidate))
+                return tests
+
+        # DOTTED OBJECT - These will discover a specific object if it is
+        # globally importable or importable from the current working directory.
+        # Examples: pkg, pkg.module, pkg.module.class, pkg.module.class.func
+        tests = None
+        if target and (target[0] != '.'):  # We don't handle relative dot objects
+            try:
+                tests = self.loadTestsFromName(target)
+                for index, test in enumerate(tests):
+                    if test.__class__.__name__ == '_FailedTest':  # pragma: no cover
+                        del(tests._tests[index])
+
+            except Exception as e:
+                debug("IGNORED exception: {}".format(e))
+            if tests and tests.countTestCases():
+                debug("Load method: DOTTED OBJECT - {}".format(target))
+                return tests
+
+        # FILE VARIATIONS - These will import a specific file and any tests
+        # accessible from its scope.
+
+        # some/file.py
+        bare_file = target
+        # some/file
+        pyless_file = target + '.py'
+        for candidate in [bare_file, pyless_file]:
+            if (candidate is None) or (not os.path.isfile(candidate)):
+                continue
+            need_cleanup = False
+            cwd = os.getcwd()
+            if cwd != sys.path[0]:
+                need_cleanup = True
+                sys.path.insert(0, cwd)
+            try:
+                dotted_path = target.replace('.py', '').replace(os.sep, '.')
+                tests = self.loadTestsFromName(dotted_path)
+            except:  # Any exception could occur here
+                # TODO: #25 - Right now this mimics the behavior in unittest.  Lets
+                # refactor it and simplify it after we make sure it works.
+                # This is a cause of the traceback mangling I observed.
+                try:
+                    message = ('Failed to import "{}":\n{}').format(
+                                   dotted_path, traceback.format_exc())
+                # If the line that caused the exception has unicode literals in it
+                # anywhere, then python 2.7 will crash on traceback.format_exc().
+                # Python 3 is ok.
+                except UnicodeDecodeError:  # pragma: no cover
+                    message = ('Failed to import "{}", and the import traceback '
+                               'has a unicode decode error, so I can\'t display '
+                               'it.'.format(dotted_path))
+
+                def testFailure(self):
+                    raise ImportError(message)
+
+                TestClass = type(
+                        str("ModuleImportFailure"),
+                        (unittest.case.TestCase,),
+                        {dotted_path: testFailure})
+                return GreenTestSuite((TestClass(dotted_path),))
+            if need_cleanup:
+                sys.path.remove(cwd)
+            if tests and tests.countTestCases():
+                debug("Load method: FILE - {}".format(candidate))
+                return tests
+
+        return None

--- a/green/loader.py
+++ b/green/loader.py
@@ -263,9 +263,18 @@ class GreenTestLoader(unittest.TestLoader):
         # --- Find the tests inside the loaded module ---
         return self.loadTestsFromModule(loaded_module)
 
-    def loadTestsFromModule(self, module, pattern=None):
-        tests = super(GreenTestLoader, self).loadTestsFromModule(module, pattern=pattern)
-        return self.flattenTestSuite(tests)
+    if sys.version_info >= (3,5):
+
+        def loadTestsFromModule(self, module, pattern=None):
+            tests = super(GreenTestLoader, self).loadTestsFromModule(module, pattern=pattern)
+            return self.flattenTestSuite(tests)
+
+    else:
+
+        def loadTestsFromModule(self, module):
+            tests = super(GreenTestLoader, self).loadTestsFromModule(module)
+            return self.flattenTestSuite(tests)
+
 
     def loadTestsFromName(self, name, module=None):
         tests = super(GreenTestLoader, self).loadTestsFromName(name, module)

--- a/green/loader.py
+++ b/green/loader.py
@@ -279,7 +279,6 @@ class GreenTestLoader(unittest.TestLoader):
             tests = super(GreenTestLoader, self).loadTestsFromModule(module)
             return self.flattenTestSuite(tests)
 
-
     def loadTestsFromName(self, name, module=None):
         tests = super(GreenTestLoader, self).loadTestsFromName(name, module)
         return self.flattenTestSuite(tests)
@@ -468,3 +467,12 @@ class GreenTestLoader(unittest.TestLoader):
                 return tests
 
         return None
+
+
+toProtoTestList = GreenTestLoader.toProtoTestList
+toParallelTargets = GreenTestLoader.toParallelTargets
+getCompletions = GreenTestLoader.getCompletions
+isPackage = GreenTestLoader.isPackage
+findDottedModuleAndParentDir = GreenTestLoader.findDottedModuleAndParentDir
+isTestCaseDisabled = GreenTestLoader.isTestCaseDisabled
+flattenTestSuite = GreenTestLoader.flattenTestSuite

--- a/green/loader.py
+++ b/green/loader.py
@@ -192,7 +192,7 @@ class GreenTestLoader(unittest.TestLoader):
 
         # For a test loader, we want to always the current working directory to
         # be the first item in sys.path, just like when a python interpreter is
-        # loaded interactively.  See also
+        # loaded interactively. See also
         # https://docs.python.org/3.4/library/sys.html#sys.path
         if sys.path[0] != '':
             sys.path.insert(0, '')

--- a/green/loader.py
+++ b/green/loader.py
@@ -94,6 +94,7 @@ class GreenTestLoader(unittest.TestLoader):
             # to the list if we haven't already.
             if test.module not in parallel_targets:
                 parallel_targets.append(test.module)
+
         return parallel_targets
 
     @classmethod
@@ -250,6 +251,9 @@ class GreenTestLoader(unittest.TestLoader):
         # --- Find the tests inside the loaded module ---
         return self.loadTestsFromModule(loaded_module)
 
+    def loadTestsFromName(self, name, module=None):
+        tests = super(GreenTestLoader, self).loadTestsFromName(name, module)
+        return self.suiteClass(tests)
 
     def discover(self, current_path, file_pattern='test*.py', top_level_dir=None):
         """
@@ -369,7 +373,7 @@ class GreenTestLoader(unittest.TestLoader):
         tests = None
         if target and (target[0] != '.'):  # We don't handle relative dot objects
             try:
-                tests = self.loadTestsFromName(target)
+                tests = self.suiteClass(self.loadTestsFromName(target))
                 for index, test in enumerate(tests):
                     if test.__class__.__name__ == '_FailedTest':  # pragma: no cover
                         del(tests._tests[index])
@@ -397,7 +401,7 @@ class GreenTestLoader(unittest.TestLoader):
                 sys.path.insert(0, cwd)
             try:
                 dotted_path = target.replace('.py', '').replace(os.sep, '.')
-                tests = self.loadTestsFromName(dotted_path)
+                tests = self.suiteClass(self.loadTestsFromName(dotted_path))
             except:  # Any exception could occur here
                 # TODO: #25 - Right now this mimics the behavior in unittest.  Lets
                 # refactor it and simplify it after we make sure it works.

--- a/green/loader.py
+++ b/green/loader.py
@@ -187,8 +187,6 @@ class GreenTestLoader(unittest.TestLoader):
 
     @classmethod
     def flattenTestSuite(cls, test_suite):
-        if not test_suite:
-            return ()
         tests = []
         for test in test_suite:
             if isinstance(test, unittest.BaseTestSuite):

--- a/green/process.py
+++ b/green/process.py
@@ -14,7 +14,7 @@ except:  # pragma: no cover
     coverage = None
 
 from green.exceptions import InitializerOrFinalizerError
-from green.loader import loadTargets
+from green.loader import GreenTestLoader
 from green.result import proto_test, ProtoTest, ProtoTestResult
 
 
@@ -289,7 +289,8 @@ def poolRunner(target, queue, coverage_number=None, omit_patterns=[]):  # pragma
     result = ProtoTestResult(start_callback, finalize_callback)
     test = None
     try:
-        test = loadTargets(target)
+        loader = GreenTestLoader()
+        test = loader.loadTargets(target)
     except:
         err = sys.exc_info()
         t             = ProtoTest()

--- a/green/runner.py
+++ b/green/runner.py
@@ -13,7 +13,7 @@ except:  # pragma: no cover
     coverage = None
 
 from green.exceptions import InitializerOrFinalizerError
-from green.loader import GreenTestLoader
+from green.loader import toParallelTargets
 from green.output import debug, GreenStream
 from green.process import LoggingDaemonlessPool, poolRunner
 from green.result import GreenTestResult
@@ -89,7 +89,8 @@ def run(suite, stream, args, testing=False):
                                      initializer=InitializerOrFinalizer(args.initializer),
                                      finalizer=InitializerOrFinalizer(args.finalizer))
         manager = multiprocessing.Manager()
-        targets = [(target, manager.Queue()) for target in GreenTestLoader.toParallelTargets(suite, args.targets)]
+        targets = [(target, manager.Queue())
+                   for target in toParallelTargets(suite, args.targets)]
         if targets:
             for index, (target, queue) in enumerate(targets):
                 if args.run_coverage:

--- a/green/runner.py
+++ b/green/runner.py
@@ -13,7 +13,7 @@ except:  # pragma: no cover
     coverage = None
 
 from green.exceptions import InitializerOrFinalizerError
-from green.loader import toParallelTargets
+from green.loader import GreenTestLoader
 from green.output import debug, GreenStream
 from green.process import LoggingDaemonlessPool, poolRunner
 from green.result import GreenTestResult
@@ -89,7 +89,7 @@ def run(suite, stream, args, testing=False):
                                      initializer=InitializerOrFinalizer(args.initializer),
                                      finalizer=InitializerOrFinalizer(args.finalizer))
         manager = multiprocessing.Manager()
-        targets = [(target, manager.Queue()) for target in toParallelTargets(suite, args.targets)]
+        targets = [(target, manager.Queue()) for target in GreenTestLoader.toParallelTargets(suite, args.targets)]
         if targets:
             for index, (target, queue) in enumerate(targets):
                 if args.run_coverage:

--- a/green/test/test_load_tests.py
+++ b/green/test/test_load_tests.py
@@ -1,14 +1,164 @@
 from __future__ import unicode_literals
 
+import os
+import shutil
+import tempfile
 import unittest
+import textwrap
 
+try:
+    from Queue import Queue, Empty
+except ImportError:
+    from queue import Queue, Empty
+
+from green.loader import GreenTestLoader
+from green.process import poolRunner
+from green import process
 
 
 class TestLoadTests(unittest.TestCase):
-    def _test_that_will_fail(self):
-        self.fail("load_tests was not executed.")
-    test_load_tests = _test_that_will_fail
 
-def load_tests(loader, tests, pattern):
-    setattr(TestLoadTests, 'test_load_tests', lambda self: None)
-    return loader.loadTestsFromTestCase(TestLoadTests)
+    @classmethod
+    def setUpClass(cls):
+        cls.startdir = os.getcwd()
+        cls.container_dir = tempfile.mkdtemp()
+
+    @classmethod
+    def tearDownClass(cls):
+        os.chdir(cls.startdir)
+        #shutil.rmtree(cls.container_dir)
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(dir=self.container_dir)
+        self.sub_tmpdir = tempfile.mkdtemp(dir=self.tmpdir)
+        self.basename = os.path.basename(self.sub_tmpdir)
+        os.chdir(self.tmpdir)
+
+        with open(os.path.join(self.basename, '__init__.py'), 'w') as f:
+            f.write('\n')
+
+    def tearDown(self):
+        os.chdir(self.container_dir)
+        shutil.rmtree(self.tmpdir)
+
+    def test_monkey_patch(self):
+        """
+        Check that monkey-patching a TestCase in the load_tests function
+        actually changes the referenced class.
+        """
+
+        with open(os.path.join(self.basename, 'test_load_tests_monkeypatch.py'), 'w') as f:
+            f.write(textwrap.dedent(
+                """
+                import unittest
+                class A(unittest.TestCase):
+                    passing = False
+                    def test_that_will_fail(self):
+                        self.assertTrue(self.passing)
+
+                def load_tests(loader, tests, pattern):
+                    A.passing = True
+                    return tests
+                """))
+
+        module_name = self.basename + '.test_load_tests_monkeypatch'
+        result = Queue()
+        poolRunner(module_name, result, 0)
+        result.get()
+
+        proto_test_result = result.get()
+        self.assertEqual(len(proto_test_result.passing), 1)
+        self.assertEqual(len(proto_test_result.failures), 0)
+        self.assertEqual(len(proto_test_result.errors), 0)
+        self.assertEqual(proto_test_result.passing[0].class_name, 'A')
+
+    def test_foreign_suite(self):
+        """
+        Load tests does not reuse the tests and instead returns
+        another TestSuite (or maybe not even a unittest.TestSuite).
+        """
+
+        with open(os.path.join(self.basename, 'test_load_keys_foreign_suite.py'), 'w') as f:
+            f.write(textwrap.dedent(
+                """
+                import unittest
+                class A(unittest.TestCase):
+                    def test_that_will_fail(self):
+                        self.fail()
+
+                def load_tests(loader, tests, pattern):
+                    class B(unittest.TestCase):
+                        def test_that_succeeds(self):
+                            pass
+                    suite = unittest.TestSuite()
+                    suite.addTests(loader.loadTestsFromTestCase(B))
+                    return suite
+                """))
+
+        module_name = self.basename + '.test_load_keys_foreign_suite'
+        result = Queue()
+        poolRunner(module_name, result, 0)
+        result.get()
+
+        proto_test_result = result.get()
+        self.assertEqual(len(proto_test_result.passing), 1)
+        self.assertEqual(len(proto_test_result.errors), 0)
+        self.assertEqual(len(proto_test_result.failures), 0)
+        self.assertEqual(proto_test_result.passing[0].class_name, 'B')
+
+    def test_none_cancels(self):
+        """
+        Check that if load_tests returns None, no tests are run.
+        """
+        with open(os.path.join(self.basename, 'test_load_keys_none_cancels.py'), 'w') as fh:
+            fh.write(textwrap.dedent(
+                """
+                import unittest
+                class A(unittest.TestCase):
+                    def test_that_will_fail(self):
+                        self.fail()
+
+                def load_tests(loader, tests, pattern):
+                    return None
+                """))
+
+        module_name = self.basename + '.test_load_keys_none_cancels'
+        result = Queue()
+        poolRunner(module_name, result, 0)
+        result.get()
+
+        proto_test_result = result.get()
+        self.assertEqual(len(proto_test_result.errors), 1)
+        self.assertEqual(len(proto_test_result.passing), 0)
+        self.assertEqual(len(proto_test_result.failures), 0)
+
+    def test_additive(self):
+        """
+        Check that adding tests to the `tests` argument of the load_tests
+        function add more tests to be run.
+        """
+
+        with open(os.path.join(self.basename, 'test_load_keys_additive.py'), 'w') as fh:
+            fh.write(textwrap.dedent(
+                """
+                import unittest
+                class A(unittest.TestCase):
+                    def test_that_will_succeed(self):
+                        pass
+
+                class B(unittest.TestCase):
+                    def test_clear_sight(self):
+                        self.fail()
+
+                    def _hidden_test(self):
+                        pass
+
+                def load_tests(loader, tests, pattern):
+                    setattr(B, 'test_that_will_succeed', B._hidden_test)
+                    tests.addTests(loader.loadTestsFromTestCase(B))
+                    return tests
+                """))
+
+        loader = GreenTestLoader()
+        test_suite = loader.loadTargets(self.basename+'.'+'test_load_keys_additive')
+        self.assertEqual(len(test_suite._tests), 4) # a + b1 + b1 + b2

--- a/green/test/test_load_tests.py
+++ b/green/test/test_load_tests.py
@@ -1,0 +1,14 @@
+from __future__ import unicode_literals
+
+import unittest
+
+
+
+class TestLoadTests(unittest.TestCase):
+    def _test_that_will_fail(self):
+        self.fail("load_tests was not executed.")
+    test_load_tests = _test_that_will_fail
+
+def load_tests(loader, tests, pattern):
+    setattr(TestLoadTests, 'test_load_tests', lambda self: None)
+    return loader.loadTestsFromTestCase(TestLoadTests)

--- a/green/test/test_loader.py
+++ b/green/test/test_loader.py
@@ -722,7 +722,7 @@ class TestLoadTargets(unittest.TestCase):
         # Load the tests
         tests = self.loader.loadTargets(malformed_module)
         self.assertEqual(tests.countTestCases(), 1)
-        test = tests._tests[0]._tests[0]
+        test = tests._tests[0]
         test_method = getattr(test, test._testMethodName)
         self.assertRaises(ImportError, test_method)
 

--- a/green/test/test_loader.py
+++ b/green/test/test_loader.py
@@ -13,6 +13,7 @@ except:
     from mock import MagicMock
 
 from green import loader
+from green.loader import GreenTestLoader
 
 
 class TestToProtoTestList(unittest.TestCase):
@@ -25,7 +26,7 @@ class TestToProtoTestList(unittest.TestCase):
         suite.__class__.__name__ = str('ModuleImportFailure')
         suite.__str__.return_value = "exception_method other_stuff"
         suite.exception_method.side_effect = AttributeError
-        self.assertRaises(AttributeError, loader.toProtoTestList, (suite,))
+        self.assertRaises(AttributeError, GreenTestLoader.toProtoTestList, (suite,))
 
     def test_moduleImportFailureIgnored(self):
         """
@@ -35,7 +36,7 @@ class TestToProtoTestList(unittest.TestCase):
         suite.__class__.__name__ = str('ModuleImportFailure')
         suite.__str__.return_value = "exception_method other_stuff"
         suite.exception_method.side_effect = AttributeError
-        self.assertEqual(loader.toProtoTestList(suite, doing_completions=True), [])
+        self.assertEqual(GreenTestLoader.toProtoTestList(suite, doing_completions=True), [])
 
 
 class TestToParallelTargets(unittest.TestCase):
@@ -69,7 +70,7 @@ class TestToParallelTargets(unittest.TestCase):
 
         NormalTestCase.__module__ = self._fake_module_name
 
-        targets = loader.toParallelTargets(NormalTestCase(), [])
+        targets = GreenTestLoader.toParallelTargets(NormalTestCase(), [])
         self.assertEqual(targets, ["my_test_module"])
 
     def test_methods_with_constraints(self):
@@ -83,7 +84,7 @@ class TestToParallelTargets(unittest.TestCase):
         NormalTestCase.__module__ = self._fake_module_name
         full_name = "my_test_module.NormalTestCase.runTest"
 
-        targets = loader.toParallelTargets(NormalTestCase(), [full_name])
+        targets = GreenTestLoader.toParallelTargets(NormalTestCase(), [full_name])
         self.assertEqual(targets, [full_name])
 
     def test_filter_out_dot(self):
@@ -101,7 +102,7 @@ class TestToParallelTargets(unittest.TestCase):
         NormalTestCase.__module__ = self._fake_module_name
         NormalTestCase2.__module__ = self._fake_module_name2
 
-        targets = loader.toParallelTargets([NormalTestCase(), NormalTestCase2()], ['.'])
+        targets = GreenTestLoader.toParallelTargets([NormalTestCase(), NormalTestCase2()], ['.'])
         self.assertEqual(targets, ["my_test_module", "my_test_module2"])
 
 
@@ -111,13 +112,13 @@ class TestCompletions(unittest.TestCase):
         """
         Bad match generates no completions
         """
-        self.assertEqual('', loader.getCompletions('garbage.in'))
+        self.assertEqual('', GreenTestLoader.getCompletions('garbage.in'))
 
     def test_completionExact(self):
         """
         Correct completions are generated for an exact match.
         """
-        c = set(loader.getCompletions('green').split('\n'))
+        c = set(GreenTestLoader.getCompletions('green').split('\n'))
         self.assertIn('green', c)
         self.assertIn('green.test', c)
         self.assertIn('green.test.test_loader', c)
@@ -133,7 +134,7 @@ class TestCompletions(unittest.TestCase):
         green_parent = dirname(dirname(dirname(os.path.abspath(__file__))))
         os.chdir(green_parent)
         self.addCleanup(os.chdir, cwd)
-        c = set(loader.getCompletions('gre').split('\n'))
+        c = set(GreenTestLoader.getCompletions('gre').split('\n'))
         self.assertIn('green', c)
         self.assertIn('green.test', c)
         self.assertIn('green.test.test_loader', c)
@@ -145,7 +146,7 @@ class TestCompletions(unittest.TestCase):
         """
         Correct completions generated for partial match.  2nd target ignored.
         """
-        c = set(loader.getCompletions(['green.te', 'green']).split('\n'))
+        c = set(GreenTestLoader.getCompletions(['green.te', 'green']).split('\n'))
         self.assertIn('green.test', c)
         self.assertIn('green.test.test_loader', c)
         self.assertIn('green.test.test_loader.TestCompletions', c)
@@ -178,7 +179,7 @@ class TestCompletions(unittest.TestCase):
                     pass
             """))
         fh.close()
-        c = set(loader.getCompletions('').split('\n'))
+        c = set(GreenTestLoader.getCompletions('').split('\n'))
         self.assertIn('the_pkg', c)
         self.assertIn('the_pkg.test_things', c)
         self.assertIn('the_pkg.test_things.A.testOne', c)
@@ -209,7 +210,7 @@ class TestCompletions(unittest.TestCase):
                     pass
             """))
         fh.close()
-        c = set(loader.getCompletions('.').split('\n'))
+        c = set(GreenTestLoader.getCompletions('.').split('\n'))
         self.assertIn('my_pkg', c)
         self.assertIn('my_pkg.test_things', c)
         self.assertIn('my_pkg.test_things.A.testOne', c)
@@ -247,7 +248,7 @@ class TestCompletions(unittest.TestCase):
         fh = open(os.path.join('my_pkg2', 'test_crash03.py'), 'w')
         fh.write(contents)
         fh.close()
-        c = set(loader.getCompletions('.').split('\n'))
+        c = set(GreenTestLoader.getCompletions('.').split('\n'))
         self.assertIn('my_pkg2', c)
         self.assertIn('my_pkg2.test_crash01', c)
         self.assertIn('my_pkg2.test_crash01.A.testOne', c)
@@ -268,7 +269,7 @@ class TestIsPackage(unittest.TestCase):
         fh = open(os.path.join(tmpdir, '__init__.py'), 'w')
         fh.write('pass\n')
         fh.close()
-        self.assertTrue(loader.isPackage(tmpdir))
+        self.assertTrue(GreenTestLoader.isPackage(tmpdir))
 
     def test_no(self):
         """
@@ -276,7 +277,7 @@ class TestIsPackage(unittest.TestCase):
         """
         tmpdir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, tmpdir)
-        self.assertFalse(loader.isPackage(tmpdir))
+        self.assertFalse(GreenTestLoader.isPackage(tmpdir))
 
 
 class TestDottedModule(unittest.TestCase):
@@ -287,7 +288,7 @@ class TestDottedModule(unittest.TestCase):
         """
         self.assertRaises(
                 ValueError,
-                loader.findDottedModuleAndParentDir, tempfile.tempdir)
+                GreenTestLoader.findDottedModuleAndParentDir, tempfile.tempdir)
 
     def test_good_path(self):
         """
@@ -303,11 +304,14 @@ class TestDottedModule(unittest.TestCase):
             fh = open(filename, 'w')
             fh.write('pass\n')
             fh.close()
-        self.assertEqual(loader.findDottedModuleAndParentDir(module),
+        self.assertEqual(GreenTestLoader.findDottedModuleAndParentDir(module),
                          ('c.d.stuff', os.path.join(tmpdir, 'a', 'b')))
 
 
-class TestLoadFromTestCase(unittest.TestCase):
+class TestLoadTestsFromTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.loader = GreenTestLoader()
 
     def test_runTest(self):
         """
@@ -324,7 +328,7 @@ class TestLoadFromTestCase(unittest.TestCase):
             def runTest(self):
                 pass
 
-        suite = loader.loadFromTestCase(MyTestCase)
+        suite = self.loader.loadTestsFromTestCase(MyTestCase)
         self.assertEqual(suite.countTestCases(), 1)
         self.assertEqual(suite._tests[0]._testMethodName, 'runTest')
 
@@ -339,7 +343,7 @@ class TestLoadFromTestCase(unittest.TestCase):
             def test_method2(self):
                 pass
 
-        suite = loader.loadFromTestCase(Normal)
+        suite = self.loader.loadTestsFromTestCase(Normal)
         self.assertEqual(suite.countTestCases(), 2)
         self.assertEqual(set([x._testMethodName for x in suite._tests]),
                          set(['test_method1', 'test_method2']))
@@ -354,11 +358,14 @@ class TestLoadFromTestCase(unittest.TestCase):
 
             test_method.__test__ = False
 
-        suite = loader.loadFromTestCase(HasDisabled)
+        suite = self.loader.loadTestsFromTestCase(HasDisabled)
         self.assertEqual(suite.countTestCases(), 0)
 
 
 class TestLoadFromModuleFilename(unittest.TestCase):
+
+    def setUp(self):
+        self.loader = GreenTestLoader()
 
     def test_skipped_module(self):
         """
@@ -379,7 +386,7 @@ class TestLoadFromModuleFilename(unittest.TestCase):
                     pass
             """))
         fh.close()
-        suite = loader.loadFromModuleFilename(filename)
+        suite = self.loader.loadFromModuleFilename(filename)
         self.assertEqual(suite.countTestCases(), 1)
         self.assertRaises(unittest.case.SkipTest,
                           getattr(suite._tests[0],
@@ -388,19 +395,22 @@ class TestLoadFromModuleFilename(unittest.TestCase):
 
 class TestDiscover(unittest.TestCase):
 
+    def setUp(self):
+        self.loader = GreenTestLoader()
+
     def test_bad_input(self):
         """
         discover() raises ImportError when passed a non-directory
         """
         tmpdir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, tmpdir)
-        self.assertRaises(ImportError, loader.discover,
+        self.assertRaises(ImportError, self.loader.discover,
                           os.path.join(tmpdir, 'garbage_in'))
         filename = os.path.join(tmpdir, 'some_file.py')
         fh = open(filename, 'w')
         fh.write('pass\n')
         fh.close()
-        self.assertRaises(ImportError, loader.discover, filename)
+        self.assertRaises(ImportError, self.loader.discover, filename)
 
     def test_bad_pkg_name(self):
         """
@@ -429,7 +439,7 @@ class TestDiscover(unittest.TestCase):
                     pass
             """))
         fh.close()
-        self.assertEqual(loader.discover(tmpdir), None)
+        self.assertEqual(self.loader.discover(tmpdir), None)
 
     def test_symlink(self):
         """
@@ -461,7 +471,7 @@ class TestDiscover(unittest.TestCase):
                     pass
             """))
         fh.close()
-        self.assertEqual(loader.discover(tmpdir2), None)
+        self.assertEqual(self.loader.discover(tmpdir2), None)
 
 
 class TestLoadTargets(unittest.TestCase):
@@ -482,6 +492,7 @@ class TestLoadTargets(unittest.TestCase):
     def setUp(self):
         os.chdir(self.container_dir)
         self.tmpdir = tempfile.mkdtemp(dir=self.container_dir)
+        self.loader = GreenTestLoader()
 
     def tearDown(self):
         os.chdir(self.container_dir)
@@ -507,16 +518,16 @@ class TestLoadTargets(unittest.TestCase):
             ))
         fh.close()
         # Discover stuff
-        suite = loader.loadTargets('.')
+        suite = self.loader.loadTargets('.')
         # This should resolve it to the module that's not importable from here
-        test = loader.toParallelTargets(suite, [])[0]
-        loader.loadTargets(test)
+        test = self.loader.toParallelTargets(suite, [])[0]
+        self.loader.loadTargets(test)
 
     def test_emptyDirAbsolute(self):
         """
         Absolute path to empty directory returns None
         """
-        tests = loader.loadTargets(self.tmpdir)
+        tests = self.loader.loadTargets(self.tmpdir)
         self.assertTrue(tests is None)
 
     def test_emptyDirRelative(self):
@@ -525,7 +536,7 @@ class TestLoadTargets(unittest.TestCase):
         """
         os.chdir(self.tmpdir)
         os.chdir('..')
-        tests = loader.loadTargets(os.path.dirname(self.tmpdir))
+        tests = self.loader.loadTargets(os.path.dirname(self.tmpdir))
         self.assertEqual(tests, None)
 
     def test_emptyDirDot(self):
@@ -533,7 +544,7 @@ class TestLoadTargets(unittest.TestCase):
         '.' while in an empty directory returns None
         """
         os.chdir(self.tmpdir)
-        tests = loader.loadTargets('.')
+        tests = self.loader.loadTargets('.')
         self.assertTrue(tests is None)
 
     def test_relativeDotDir(self):
@@ -543,7 +554,7 @@ class TestLoadTargets(unittest.TestCase):
         os.chdir(self.tmpdir)
         os.chdir('..')
         target = os.path.join('.', os.path.basename(self.tmpdir))
-        tests = loader.loadTargets(target)
+        tests = self.loader.loadTargets(target)
         self.assertTrue(tests is None)
 
     def test_BigDirWithAbsoluteImports(self):
@@ -579,12 +590,12 @@ class TestLoadTargets(unittest.TestCase):
         fh.close()
         # Load the tests
         os.chdir(self.tmpdir)
-        test_suite = loader.loadTargets(pkg_name)
+        test_suite = self.loader.loadTargets(pkg_name)
         self.assertEqual(test_suite.countTestCases(), 1)
         # Dotted name should start with the package!
         self.assertEqual(
                 pkg_name + '.test.test_target_module.A.testPass',
-                loader.toProtoTestList(test_suite)[0].dotted_name)
+                self.loader.toProtoTestList(test_suite)[0].dotted_name)
 
     def test_DirWithInit(self):
         """
@@ -609,7 +620,7 @@ class TestLoadTargets(unittest.TestCase):
         fh.close()
         # Load the tests
         module_name = os.path.basename(self.tmpdir)
-        tests = loader.loadTargets(module_name)
+        tests = self.loader.loadTargets(module_name)
         self.assertEqual(tests.countTestCases(), 1)
 
     def test_DottedName(self):
@@ -635,7 +646,7 @@ class TestLoadTargets(unittest.TestCase):
         fh.close()
         # Load the tests
         module_name = basename + ".test_module_dotted_name"
-        tests = loader.loadTargets(module_name)
+        tests = self.loader.loadTargets(module_name)
         self.assertEqual(tests.countTestCases(), 1)
 
     def test_DottedNamePackageFromPath(self):
@@ -661,7 +672,7 @@ class TestLoadTargets(unittest.TestCase):
         os.chdir(self.startdir)
         sys.path.insert(0, self.tmpdir)
         # Load the tests
-        tests = loader.loadTargets(os.path.basename(tmp_subdir))
+        tests = self.loader.loadTargets(os.path.basename(tmp_subdir))
         sys.path.remove(self.tmpdir)
         self.assertTrue(tests.countTestCases(), 1)
 
@@ -686,7 +697,7 @@ class TestLoadTargets(unittest.TestCase):
             """))
         fh.close()
         # Load the tests
-        tests = loader.loadTargets(named_module)
+        tests = self.loader.loadTargets(named_module)
         try:
             self.assertEqual(tests.countTestCases(), 1)
         except:
@@ -708,7 +719,7 @@ class TestLoadTargets(unittest.TestCase):
         fh.write("This is a malformed module.")
         fh.close()
         # Load the tests
-        tests = loader.loadTargets(malformed_module)
+        tests = self.loader.loadTargets(malformed_module)
         self.assertEqual(tests.countTestCases(), 1)
         test = tests._tests[0]._tests[0]
         test_method = getattr(test, test._testMethodName)
@@ -737,7 +748,7 @@ class TestLoadTargets(unittest.TestCase):
         fh.close()
         # Load the tests
         module_name = basename + ".existing_module.nonexistant_object"
-        tests = loader.loadTargets(module_name)
+        tests = self.loader.loadTargets(module_name)
         self.assertEqual(tests, None)
 
     def test_multiple_targets(self):
@@ -772,8 +783,8 @@ class TestLoadTargets(unittest.TestCase):
         # Load the tests
         os.chdir(self.tmpdir)
         pkg = os.path.basename(sub_tmpdir)
-        tests = loader.loadTargets([pkg + '.' + 'test_target1',
-                                    pkg + '.' + 'test_target2'])
+        tests = self.loader.loadTargets([pkg + '.' + 'test_target1',
+                                         pkg + '.' + 'test_target2'])
         self.assertEqual(tests.countTestCases(), 2)
 
     def test_duplicate_targets(self):
@@ -796,9 +807,9 @@ class TestLoadTargets(unittest.TestCase):
 
         os.chdir(self.tmpdir)
         pkg = os.path.basename(sub_tmpdir)
-        tests = loader.loadTargets([pkg + '.' + 'test_dupe_target',
-                                    pkg + '.' + 'test_dupe_target',
-                                    pkg + '.' + 'test_dupe_target'])
+        tests = self.loader.loadTargets([pkg + '.' + 'test_dupe_target',
+                                         pkg + '.' + 'test_dupe_target',
+                                         pkg + '.' + 'test_dupe_target'])
         self.assertEqual(tests.countTestCases(), 1)
 
     def test_explicit_filename_error(self):
@@ -812,7 +823,7 @@ class TestLoadTargets(unittest.TestCase):
         fh.close()
 
         os.chdir(sub_tmpdir)
-        tests = loader.loadTargets('mod_with_import_error.py')
+        tests = self.loader.loadTargets('mod_with_import_error.py')
         self.assertEqual(tests.countTestCases(), 1)
 
     def test_file_pattern(self):
@@ -857,5 +868,5 @@ class TestLoadTargets(unittest.TestCase):
         # Load the tests
         os.chdir(self.tmpdir)
         pkg = os.path.basename(sub_tmpdir)
-        tests = loader.loadTargets(pkg, file_pattern='*_tests.py')
+        tests = self.loader.loadTargets(pkg, file_pattern='*_tests.py')
         self.assertEqual(tests.countTestCases(), 2)

--- a/green/test/test_loader.py
+++ b/green/test/test_loader.py
@@ -26,7 +26,7 @@ class TestToProtoTestList(unittest.TestCase):
         suite.__class__.__name__ = str('ModuleImportFailure')
         suite.__str__.return_value = "exception_method other_stuff"
         suite.exception_method.side_effect = AttributeError
-        self.assertRaises(AttributeError, GreenTestLoader.toProtoTestList, (suite,))
+        self.assertRaises(AttributeError, loader.toProtoTestList, (suite,))
 
     def test_moduleImportFailureIgnored(self):
         """
@@ -36,7 +36,7 @@ class TestToProtoTestList(unittest.TestCase):
         suite.__class__.__name__ = str('ModuleImportFailure')
         suite.__str__.return_value = "exception_method other_stuff"
         suite.exception_method.side_effect = AttributeError
-        self.assertEqual(GreenTestLoader.toProtoTestList(suite, doing_completions=True), [])
+        self.assertEqual(loader.toProtoTestList(suite, doing_completions=True), [])
 
 
 class TestToParallelTargets(unittest.TestCase):
@@ -70,7 +70,7 @@ class TestToParallelTargets(unittest.TestCase):
 
         NormalTestCase.__module__ = self._fake_module_name
 
-        targets = GreenTestLoader.toParallelTargets(NormalTestCase(), [])
+        targets = loader.toParallelTargets(NormalTestCase(), [])
         self.assertEqual(targets, ["my_test_module"])
 
     def test_methods_with_constraints(self):
@@ -84,7 +84,7 @@ class TestToParallelTargets(unittest.TestCase):
         NormalTestCase.__module__ = self._fake_module_name
         full_name = "my_test_module.NormalTestCase.runTest"
 
-        targets = GreenTestLoader.toParallelTargets(NormalTestCase(), [full_name])
+        targets = loader.toParallelTargets(NormalTestCase(), [full_name])
         self.assertEqual(targets, [full_name])
 
     def test_filter_out_dot(self):
@@ -102,7 +102,7 @@ class TestToParallelTargets(unittest.TestCase):
         NormalTestCase.__module__ = self._fake_module_name
         NormalTestCase2.__module__ = self._fake_module_name2
 
-        targets = GreenTestLoader.toParallelTargets([NormalTestCase(), NormalTestCase2()], ['.'])
+        targets = loader.toParallelTargets([NormalTestCase(), NormalTestCase2()], ['.'])
         self.assertEqual(targets, ["my_test_module", "my_test_module2"])
 
 
@@ -112,13 +112,13 @@ class TestCompletions(unittest.TestCase):
         """
         Bad match generates no completions
         """
-        self.assertEqual('', GreenTestLoader.getCompletions('garbage.in'))
+        self.assertEqual('', loader.getCompletions('garbage.in'))
 
     def test_completionExact(self):
         """
         Correct completions are generated for an exact match.
         """
-        c = set(GreenTestLoader.getCompletions('green').split('\n'))
+        c = set(loader.getCompletions('green').split('\n'))
         self.assertIn('green', c)
         self.assertIn('green.test', c)
         self.assertIn('green.test.test_loader', c)
@@ -134,7 +134,7 @@ class TestCompletions(unittest.TestCase):
         green_parent = dirname(dirname(dirname(os.path.abspath(__file__))))
         os.chdir(green_parent)
         self.addCleanup(os.chdir, cwd)
-        c = set(GreenTestLoader.getCompletions('gre').split('\n'))
+        c = set(loader.getCompletions('gre').split('\n'))
         self.assertIn('green', c)
         self.assertIn('green.test', c)
         self.assertIn('green.test.test_loader', c)
@@ -146,7 +146,7 @@ class TestCompletions(unittest.TestCase):
         """
         Correct completions generated for partial match.  2nd target ignored.
         """
-        c = set(GreenTestLoader.getCompletions(['green.te', 'green']).split('\n'))
+        c = set(loader.getCompletions(['green.te', 'green']).split('\n'))
         self.assertIn('green.test', c)
         self.assertIn('green.test.test_loader', c)
         self.assertIn('green.test.test_loader.TestCompletions', c)
@@ -179,7 +179,7 @@ class TestCompletions(unittest.TestCase):
                     pass
             """))
         fh.close()
-        c = set(GreenTestLoader.getCompletions('').split('\n'))
+        c = set(loader.getCompletions('').split('\n'))
         self.assertIn('the_pkg', c)
         self.assertIn('the_pkg.test_things', c)
         self.assertIn('the_pkg.test_things.A.testOne', c)
@@ -210,7 +210,7 @@ class TestCompletions(unittest.TestCase):
                     pass
             """))
         fh.close()
-        c = set(GreenTestLoader.getCompletions('.').split('\n'))
+        c = set(loader.getCompletions('.').split('\n'))
         self.assertIn('my_pkg', c)
         self.assertIn('my_pkg.test_things', c)
         self.assertIn('my_pkg.test_things.A.testOne', c)
@@ -248,7 +248,7 @@ class TestCompletions(unittest.TestCase):
         fh = open(os.path.join('my_pkg2', 'test_crash03.py'), 'w')
         fh.write(contents)
         fh.close()
-        c = set(GreenTestLoader.getCompletions('.').split('\n'))
+        c = set(loader.getCompletions('.').split('\n'))
         self.assertIn('my_pkg2', c)
         self.assertIn('my_pkg2.test_crash01', c)
         self.assertIn('my_pkg2.test_crash01.A.testOne', c)
@@ -269,7 +269,7 @@ class TestIsPackage(unittest.TestCase):
         fh = open(os.path.join(tmpdir, '__init__.py'), 'w')
         fh.write('pass\n')
         fh.close()
-        self.assertTrue(GreenTestLoader.isPackage(tmpdir))
+        self.assertTrue(loader.isPackage(tmpdir))
 
     def test_no(self):
         """
@@ -277,7 +277,7 @@ class TestIsPackage(unittest.TestCase):
         """
         tmpdir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, tmpdir)
-        self.assertFalse(GreenTestLoader.isPackage(tmpdir))
+        self.assertFalse(loader.isPackage(tmpdir))
 
 
 class TestDottedModule(unittest.TestCase):
@@ -288,7 +288,7 @@ class TestDottedModule(unittest.TestCase):
         """
         self.assertRaises(
                 ValueError,
-                GreenTestLoader.findDottedModuleAndParentDir,
+                loader.findDottedModuleAndParentDir,
                 tempfile.tempdir)
 
     def test_good_path(self):
@@ -305,7 +305,7 @@ class TestDottedModule(unittest.TestCase):
             fh = open(filename, 'w')
             fh.write('pass\n')
             fh.close()
-        self.assertEqual(GreenTestLoader.findDottedModuleAndParentDir(module),
+        self.assertEqual(loader.findDottedModuleAndParentDir(module),
                          ('c.d.stuff', os.path.join(tmpdir, 'a', 'b')))
 
 
@@ -521,7 +521,7 @@ class TestLoadTargets(unittest.TestCase):
         # Discover stuff
         suite = self.loader.loadTargets('.')
         # This should resolve it to the module that's not importable from here
-        test = self.loader.toParallelTargets(suite, [])[0]
+        test =loader.toParallelTargets(suite, [])[0]
         self.loader.loadTargets(test)
 
     def test_emptyDirAbsolute(self):
@@ -596,7 +596,7 @@ class TestLoadTargets(unittest.TestCase):
         # Dotted name should start with the package!
         self.assertEqual(
                 pkg_name + '.test.test_target_module.A.testPass',
-                self.loader.toProtoTestList(test_suite)[0].dotted_name)
+                loader.toProtoTestList(test_suite)[0].dotted_name)
 
     def test_DirWithInit(self):
         """

--- a/green/test/test_loader.py
+++ b/green/test/test_loader.py
@@ -288,7 +288,8 @@ class TestDottedModule(unittest.TestCase):
         """
         self.assertRaises(
                 ValueError,
-                GreenTestLoader.findDottedModuleAndParentDir, tempfile.tempdir)
+                GreenTestLoader.findDottedModuleAndParentDir,
+                tempfile.tempdir)
 
     def test_good_path(self):
         """

--- a/green/test/test_runner.py
+++ b/green/test/test_runner.py
@@ -12,7 +12,7 @@ import weakref
 
 from green.config import default_args
 from green.exceptions import InitializerOrFinalizerError
-from green.loader import loadTargets
+from green.loader import GreenTestLoader
 from green.output import GreenStream
 from green.runner import InitializerOrFinalizer, run
 from green.suite import GreenTestSuite
@@ -119,6 +119,7 @@ class TestRun(unittest.TestCase):
         self.args = copy.deepcopy(default_args)
         self.stream = StringIO()
         self.tmpdir = tempfile.mkdtemp()
+        self.loader = GreenTestLoader()
 
     def tearDown(self):
         del(self.tmpdir)
@@ -158,7 +159,7 @@ class TestRun(unittest.TestCase):
             """.format(os.getpid())))
         fh.close()
         os.chdir(sub_tmpdir)
-        tests = loadTargets('test_verbose3')
+        tests = self.loader.loadTargets('test_verbose3')
         result = run(tests, self.stream, self.args)
         os.chdir(self.startdir)
         self.assertEqual(result.testsRun, 1)
@@ -181,7 +182,7 @@ class TestRun(unittest.TestCase):
             """.format(os.getpid())))
         fh.close()
         os.chdir(sub_tmpdir)
-        tests = loadTargets('test_warnings')
+        tests = self.loader.loadTargets('test_warnings')
         result = run(tests, self.stream, self.args)
         os.chdir(self.startdir)
         self.assertEqual(result.testsRun, 1)
@@ -211,7 +212,7 @@ class TestRun(unittest.TestCase):
             """.format(os.getpid())))
         fh.close()
         os.chdir(sub_tmpdir)
-        tests = loadTargets('test_failed')
+        tests = self.loader.loadTargets('test_failed')
         result = run(tests, self.stream, self.args)
         os.chdir(self.startdir)
         self.assertEqual(result.testsRun, 1)
@@ -234,7 +235,7 @@ class TestRun(unittest.TestCase):
             """.format(os.getpid())))
         fh.close()
         os.chdir(sub_tmpdir)
-        tests = loadTargets('test_failfast')
+        tests = self.loader.loadTargets('test_failfast')
         self.args.failfast = True
         result = run(tests, self.stream, self.args)
         os.chdir(self.startdir)
@@ -257,7 +258,7 @@ class TestRun(unittest.TestCase):
             """.format(os.getpid())))
         fh.close()
         os.chdir(sub_tmpdir)
-        tests = loadTargets('test_systemexit')
+        tests = self.loader.loadTargets('test_systemexit')
         result = run(tests, self.stream, self.args)
         os.chdir(self.startdir)
         self.assertEqual(result.testsRun, 2)
@@ -283,6 +284,7 @@ class TestProcesses(unittest.TestCase):
         self.tmpdir = tempfile.mkdtemp(dir=self.container_dir)
         self.stream = StringIO()
         self.args = copy.deepcopy(default_args)
+        self.loader = GreenTestLoader()
 
     def tearDown(self):
         os.chdir(self.startdir)
@@ -316,7 +318,7 @@ class TestProcesses(unittest.TestCase):
             """.format(os.getpid())))
         fh.close()
         os.chdir(sub_tmpdir)
-        tests = loadTargets('test_sigint')
+        tests = self.loader.loadTargets('test_sigint')
         self.args.processes = 2
         run(tests, self.stream, self.args)
         os.chdir(TestProcesses.startdir)
@@ -378,7 +380,7 @@ class TestProcesses(unittest.TestCase):
         fh.close()
         # Load the tests
         os.chdir(self.tmpdir)
-        tests = loadTargets('.')
+        tests = self.loader.loadTargets('.')
         self.args.processes = 2
         self.args.termcolor = False
         try:
@@ -407,7 +409,7 @@ class TestProcesses(unittest.TestCase):
         fh.close()
         # Load the tests
         os.chdir(self.tmpdir)
-        tests = loadTargets('.')
+        tests = self.loader.loadTargets('.')
         self.args.processes = 0
         run(tests, self.stream, self.args)
         os.chdir(TestProcesses.startdir)
@@ -436,7 +438,7 @@ class TestProcesses(unittest.TestCase):
         fh.close()
         # Load the tests
         os.chdir(self.tmpdir)
-        tests = loadTargets('.')
+        tests = self.loader.loadTargets('.')
         self.args.processes = 2
         self.args.run_coverage = True
         self.args.cov = MagicMock()
@@ -459,7 +461,7 @@ class TestProcesses(unittest.TestCase):
         fh.close()
         # Load the tests
         os.chdir(self.tmpdir)
-        tests = loadTargets('.')
+        tests = self.loader.loadTargets('.')
         self.args.processes = 2
         os.chdir(TestProcesses.startdir)
         self.assertRaises(ImportError, run, tests, self.stream, self.args)
@@ -491,7 +493,7 @@ class TestProcesses(unittest.TestCase):
         fh.close()
         # Load the tests
         os.chdir(self.tmpdir)
-        tests = loadTargets('.')
+        tests = self.loader.loadTargets('.')
         self.args.processes = 2
         run(tests, self.stream, self.args)
         os.chdir(TestProcesses.startdir)

--- a/green/test/test_suite.py
+++ b/green/test/test_suite.py
@@ -18,7 +18,7 @@ except:
     from mock import MagicMock
 
 from green.config import default_args
-from green.loader import loadTargets
+from green.loader import GreenTestLoader
 from green.runner import run
 from green.suite import GreenTestSuite
 
@@ -126,6 +126,7 @@ class TestFunctional(unittest.TestCase):
         self.args = copy.deepcopy(default_args)
         self.stream = StringIO()
         self.tmpdir = tempfile.mkdtemp()
+        self.loader = GreenTestLoader()
 
     def tearDown(self):
         del(self.tmpdir)
@@ -152,7 +153,8 @@ class TestFunctional(unittest.TestCase):
             """.format(os.getpid())))
         fh.close()
         os.chdir(sub_tmpdir)
-        tests = loadTargets('test_skipped')
+
+        tests = self.loader.loadTargets('test_skipped')
         result = run(tests, self.stream, self.args)
         os.chdir(self.startdir)
         self.assertEqual(len(result.skipped), 2)


### PR DESCRIPTION
In regards with #87 and #88, I implemented the load_test protocol. To do so, I actually moved functions from `green.loader` to a new class `green.loader.GreenTestLoader`, inheriting from `unittest.TestLoader`.

This way, you can actually use the builtin `unittest.TestLoader.loadTestFromName`, which can run `load_tests` if needed.

Changes are **backwards-incompatible** (although some compatibility patches can be made), as I registered all functions of `green.loader` as methods of `green.loader.GreenTestLoader`.

I also removed `green.loader.loadFromModule` as it was duplicating the `unittest.TestLoader.loadFromModule` code.

I added a test containing a `TestCase` that is expected to fail, but the `load_tests` function in it will
monkey patch the `TestCase` and make the test succeed.