### PR TITLE
Implement setup.py runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Features
 - **Convenient** - Bash-completion and ZSH-completion of options and test targets.
 - **Thorough** - Built-in, optional integration with
   [coverage](http://nedbatchelder.com/code/coverage/).
+- **Embedded** - Can be run with a setup command without in-site installation.
 - **Modern** - Supports Python 2.7, and 3.4+. Additionally, [PyPy](http://pypy.org) is supported on a best-effort basis.
 - **Portable** - macOS, Linux, and BSDs are fully supported.  Windows is supported on a best-effort basis.
 - **Living** - This project grows and changes.  See the
@@ -129,6 +130,36 @@ which green >& /dev/null && source "$( green --completion-file )"
 Green has built-in integration support for the
 [coverage](http://coverage.readthedocs.org/) module.  Just make sure `coverage`
 is installed, and then add `-r` or `--run-coverage` when you run green.
+
+### `setup.py` command
+
+Green is available as a `setup.py` runner, invoked as any other setup command:
+```
+python setup.py green
+```
+This simply requires green to be present in the `setup_requires` section of
+your `setup.py` file. To run green on a specific target, use the `test_suite`
+argument (or leave blank to let green discover tests itself):
+```python
+# setup.py
+from setuptools import setup
+
+setup(
+    ...
+    setup_requires = ['green'],
+    # test_suite = ["my_project.tests"]
+)
+```
+
+You can also add an alias to the `setup.cfg` file, so that `python setup.py test` actually runs green:
+
+```ini
+# setup.cfg
+
+[aliases]
+test = green
+```
+
 
 ### Django
 
@@ -501,5 +532,3 @@ some awesome suggestions?  Whatever the case, go submit it as an
 not picky about what goes into the Issue tracker.  Questions, comments, bugs,
 feature requests, just letting me know that I should go look at some other cool
 tool.  Go for it.
-
-

--- a/green/cmdline.py
+++ b/green/cmdline.py
@@ -13,7 +13,7 @@ except:  # pragma: no cover
 import green.config as config
 
 
-def main(testing=False):
+def main(argv=sys.argv[1:], testing=False):
     args = config.parseArguments()
     args = config.mergeConfig(args, testing)
 
@@ -23,7 +23,7 @@ def main(testing=False):
     # Clear out all the passed-in-options just in case someone tries to run a
     # test that assumes sys.argv is clean.  I can't guess at the script name
     # that they want, though, so we'll just leave ours.
-    sys.argv = sys.argv[:1]
+    #sys.argv = sys.argv[:1]
 
     # Set up our various main objects
     from green.loader import GreenTestLoader, getCompletions

--- a/green/cmdline.py
+++ b/green/cmdline.py
@@ -13,7 +13,7 @@ except:  # pragma: no cover
 import green.config as config
 
 
-def main(argv=sys.argv[1:], testing=False):
+def main(argv=None, testing=False):
     args = config.parseArguments(argv)
     args = config.mergeConfig(args, testing)
 
@@ -23,7 +23,7 @@ def main(argv=sys.argv[1:], testing=False):
     # Clear out all the passed-in-options just in case someone tries to run a
     # test that assumes sys.argv is clean.  I can't guess at the script name
     # that they want, though, so we'll just leave ours.
-    #sys.argv = sys.argv[:1]
+    sys.argv = sys.argv[:1]
 
     # Set up our various main objects
     from green.loader import GreenTestLoader, getCompletions

--- a/green/cmdline.py
+++ b/green/cmdline.py
@@ -14,7 +14,7 @@ import green.config as config
 
 
 def main(argv=sys.argv[1:], testing=False):
-    args = config.parseArguments()
+    args = config.parseArguments(argv)
     args = config.mergeConfig(args, testing)
 
     if args.shouldExit:

--- a/green/command.py
+++ b/green/command.py
@@ -42,6 +42,13 @@ class green(Command):
     def run(self):
         self.ensure_finalized()
 
+        if self.distribution.install_requires:
+            self.distribution.fetch_build_eggs(
+                self.distribution.install_requires)
+        if self.distribution.tests_require:
+            self.distribution.fetch_build_eggs(
+                self.distribution.tests_require)
+
         script_args = self.distribution.script_args[1:]
         if self.distribution.test_suite is not None:
             script_args.append(self.distribution.test_suite)

--- a/green/command.py
+++ b/green/command.py
@@ -1,0 +1,46 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+
+try:
+    from setuptools import Command
+except ImportError:
+    from distutils.cmd import Command
+
+from green.config import parseArguments
+from green.cmdline import main
+
+
+def get_user_options():
+    r = parseArguments()
+
+    options = []
+
+    for action in r.store_opt.actions:
+        names = [name.lstrip('-') for name in action.option_strings]
+        if len(names) == 1: names.insert(0, None)
+        if not action.const: names[1] += "="
+        options.append((names[1], names[0], action.help))
+
+    return options
+
+
+class green(Command):
+
+    command_name = "green"
+    description = " green is a clean, colorful, fast python test runner"
+    user_options = get_user_options()
+
+    def initialize_options(self):
+        for name, _, _ in self.user_options:
+            setattr(self, name.replace('-', '_'), None)
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        self.ensure_finalized()
+
+        #print(vars(self.distribution))
+        error_code = main(self.distribution.script_args[1:])
+        if error_code:
+            sys.exit(error_code)

--- a/green/command.py
+++ b/green/command.py
@@ -1,9 +1,11 @@
 from __future__ import unicode_literals
 from __future__ import print_function
 
+import sys
+
 try:
     from setuptools import Command
-except ImportError:
+except ImportError: # pragma: no cover
     from distutils.cmd import Command
 
 from green.config import parseArguments
@@ -32,7 +34,7 @@ class green(Command):
 
     def initialize_options(self):
         for name, _, _ in self.user_options:
-            setattr(self, name.replace('-', '_'), None)
+            setattr(self, name.replace('-', '_').rstrip('='), None)
 
     def finalize_options(self):
         pass
@@ -40,7 +42,10 @@ class green(Command):
     def run(self):
         self.ensure_finalized()
 
-        #print(vars(self.distribution))
-        error_code = main(self.distribution.script_args[1:])
+        script_args = self.distribution.script_args[1:]
+        if self.distribution.test_suite is not None:
+            script_args.append(self.distribution.test_suite)
+
+        error_code = main(script_args)
         if error_code:
             sys.exit(error_code)

--- a/green/command.py
+++ b/green/command.py
@@ -18,9 +18,9 @@ def get_user_options():
     options = []
 
     for action in r.store_opt.actions:
-        names = [name.lstrip('-') for name in action.option_strings]
+        names = [str(name.lstrip('-')) for name in action.option_strings]
         if len(names) == 1: names.insert(0, None)
-        if not action.const: names[1] += "="
+        if not action.const: names[1] += str("=")
         options.append((names[1], names[0], action.help))
 
     return options

--- a/green/config.py
+++ b/green/config.py
@@ -63,7 +63,7 @@ default_args             = argparse.Namespace(  # pragma: no cover
         )
 
 
-class StoreOpt():  # pragma: no cover
+class StoreOpt(object):  # pragma: no cover
     """
     Helper class for storing lists of the options themselves to hand out to the
     shell completion scripts.
@@ -71,13 +71,14 @@ class StoreOpt():  # pragma: no cover
 
     def __init__(self):
         self.options = []
-        self.options = []
+        self.actions = []
 
     def __call__(self, action):
+        self.actions.append(action)
         self.options.extend(action.option_strings[0:2])
 
 
-def parseArguments():  # pragma: no cover
+def parseArguments(argv=None):  # pragma: no cover
     """
     I parse arguments in sys.argv and return the args object.  The parser
     itself is available as args.parser.
@@ -293,7 +294,7 @@ def parseArguments():  # pragma: no cover
         help="Output all options.  Used by bash- and zsh-completion.",
         default=argparse.SUPPRESS))
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv or None)
 
     # Add additional members
     args.parser    = parser

--- a/green/config.py
+++ b/green/config.py
@@ -108,6 +108,24 @@ def parseArguments(argv=None):  # pragma: no cover
                   Warning!  Generating a completion list actually discovers and loads tests
                   -- this can be very slow if you run it in huge directories!
 
+                SETUP.PY RUNNER
+
+                  To run green as a setup.py command, simply add green to the 'setup_requires'
+                  section in the setup.py file, and specify a target as the 'test_suite'
+                  parameter if you do not want green to load all the tests:
+
+                     setup(
+                         setup_requires = ['green'],
+                         install_requires = 'myproject.tests'
+                     )
+
+                  Then simply run green as any other setup.py command (it accepts the same
+                  parameters as the 'green' executable):
+
+                     python setup.py green
+                     python setup.py green -r   # to run with coverage, etc.
+
+
                 CONFIG FILES
 
 

--- a/green/config.py
+++ b/green/config.py
@@ -294,7 +294,7 @@ def parseArguments(argv=None):  # pragma: no cover
         help="Output all options.  Used by bash- and zsh-completion.",
         default=argparse.SUPPRESS))
 
-    args = parser.parse_args(argv or None)
+    args = parser.parse_args(argv)
 
     # Add additional members
     args.parser    = parser

--- a/green/test/test_cmdline.py
+++ b/green/test/test_cmdline.py
@@ -42,8 +42,8 @@ class TestMain(unittest.TestCase):
         cwd = os.getcwd()
         os.chdir(tmpdir)
         sys.path.insert(0, cwd)
-        config.sys.argv = ['', tmpdir]
-        cmdline.main()
+        argv = [tmpdir]
+        cmdline.main(argv)
         os.chdir(cwd)
         del(sys.path[0])
         shutil.rmtree(tmpdir)
@@ -57,16 +57,16 @@ class TestMain(unittest.TestCase):
         fh = open(filename, 'w')
         fh.write("debug = 2")
         fh.close()
-        cmdline.sys.argv = ['', '-dd', '--config', filename]
-        cmdline.main(testing=True)
+        argv = ['-dd', '--config', filename]
+        cmdline.main(argv, testing=True)
         shutil.rmtree(tmpdir)
 
     def test_completionFile(self):
         """
         --completion-file causes a version string to be output
         """
-        config.sys.argv = ['', '--completion-file']
-        cmdline.main(testing=True)
+        argv = ['--completion-file']
+        cmdline.main(argv, testing=True)
         self.assertIn('shell_completion.sh', self.s.getvalue())
 
     def test_completions(self):
@@ -76,8 +76,8 @@ class TestMain(unittest.TestCase):
         cwd = os.getcwd()
         path = os.path.abspath(__file__)
         os.chdir(os.path.dirname(os.path.dirname(os.path.dirname(path))))
-        config.sys.argv = ['', '--completions', 'green']
-        cmdline.main(testing=True)
+        argv = ['--completions', 'green']
+        cmdline.main(argv, testing=True)
         os.chdir(cwd)
         self.assertIn('green.test', self.s.getvalue())
 
@@ -85,8 +85,8 @@ class TestMain(unittest.TestCase):
         """
         --options causes options to be output
         """
-        cmdline.sys.argv = ['', '--options']
-        cmdline.main(testing=True)
+        argv = ['--options']
+        cmdline.main(argv, testing=True)
         self.assertIn('--options', self.s.getvalue())
         self.assertIn('--version', self.s.getvalue())
 
@@ -94,8 +94,8 @@ class TestMain(unittest.TestCase):
         """
         --version causes a version string to be output
         """
-        cmdline.sys.argv = ['', '--version']
-        cmdline.main(testing=True)
+        argv = ['--version']
+        cmdline.main(argv, testing=True)
         self.assertIn('Green', self.s.getvalue())
         self.assertIn('Python', self.s.getvalue())
 
@@ -103,11 +103,11 @@ class TestMain(unittest.TestCase):
         """
         --debug causes the log-level to be set to debug
         """
-        config.sys.argv = ['', '--debug']
+        argv = ['--debug']
         saved_basicConfig = config.logging.basicConfig
         self.addCleanup(setattr, config.logging, 'basicConfig', saved_basicConfig)
         config.logging.basicConfig = MagicMock()
-        cmdline.main(testing=True)
+        cmdline.main(argv, testing=True)
         config.logging.basicConfig.assert_called_with(
             level=logging.DEBUG,
             format="%(asctime)s %(levelname)9s %(message)s",
@@ -117,15 +117,15 @@ class TestMain(unittest.TestCase):
         """
         --notermcolor causes coverage of the line disabling termcolor
         """
-        cmdline.sys.argv = ['', '--notermcolor']
-        cmdline.main(testing=True)
+        argv = ['--notermcolor']
+        cmdline.main(argv, testing=True)
 
     def test_disableWindowsSupport(self):
         """
         --disable-windows
         """
-        cmdline.sys.argv = ['', '--disable-windows']
-        cmdline.main(testing=True)
+        argv = ['--disable-windows']
+        cmdline.main(argv, testing=True)
 
     def test_noCoverage(self):
         """
@@ -135,8 +135,8 @@ class TestMain(unittest.TestCase):
         config.sys.stdout = MagicMock()
         save_coverage = config.coverage
         config.coverage = None
-        config.sys.argv = ['', '--run-coverage']
-        self.assertEqual(cmdline.main(), 3)
+        argv = ['--run-coverage']
+        self.assertEqual(cmdline.main(argv), 3)
         config.coverage = save_coverage
         config.sys.stdout = save_stdout
 
@@ -146,8 +146,8 @@ class TestMain(unittest.TestCase):
         Coverage test, since loading the module inside the main function (due
         to coverage handling constraints) prevents injecting a mock.
         """
-        cmdline.sys.argv = ['', '/tmp/non-existent/path']
-        cmdline.main(testing=True)
+        argv = ['', '/tmp/non-existent/path']
+        cmdline.main(argv, testing=True)
 
     def test_import_cmdline_module(self):
         """

--- a/green/test/test_command.py
+++ b/green/test/test_command.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     from distutil.dist import Distribution
 
-from mock import patch
+from mock import patch, MagicMock, call
 
 from green import command
 from green.config import StoreOpt
@@ -105,3 +105,18 @@ class TestCommand(unittest.TestCase):
         with self.assertRaises(SystemExit) as se:
             cmd.run()
         self.assertEqual(se.exception.code, 125)
+
+    @patch('green.command.main', return_value=0)
+    def test_requires(self, main):
+        d = Distribution({'script_name': 'setup.py',
+                          'script_args': ['green'],
+                          'install_requires': ['six'],
+                          'tests_require': ['mock', 'unittest2']})
+        d.fetch_build_eggs = MagicMock()
+        cmd = command.green(d)
+        cmd.run()
+
+        d.fetch_build_eggs.assert_has_calls([
+            call(['six']),
+            call(['mock', 'unittest2']),
+        ])

--- a/green/test/test_command.py
+++ b/green/test/test_command.py
@@ -1,0 +1,107 @@
+from __future__ import unicode_literals
+
+import argparse
+import unittest
+import contextlib
+
+try:
+    from setuptools.dist import Distribution
+except ImportError:
+    from distutil.dist import Distribution
+
+from mock import patch
+
+from green import command
+from green.config import StoreOpt
+
+
+class TestCommand(unittest.TestCase):
+
+
+    @contextlib.contextmanager
+    def environ(self, setup_cfg=None, *args, **variables):
+
+        args = ['green'] + list(args)
+
+        if setup_cfg is not None:
+            parser = ConfigParser()
+            parser.add_section('green')
+            for k, v in setup_cfg.items():
+                parser.set('green', k, str(v))
+            with open('setup.cfg', 'w') as f:
+                parser.write(f)
+
+        yield Distribution({'script_name': 'setup.py',
+                            'script_args': args or ['green']})
+
+        #finally:
+        if os.path.isfile('setup.cfg'):
+            os.remove('setup.cfg')
+
+    def test_get_user_options(self):
+        # Check the user options contain some of the
+        # actual command line options
+        options = command.get_user_options()
+
+        self.assertIn(
+            ("options", None,
+             "Output all options.  Used by bash- and zsh-completion."),
+            options
+        )
+
+        self.assertIn(
+            ('file-pattern=', 'p',
+             'Pattern to match test files. Default is test*.py'),
+            options
+        )
+
+    @patch('green.command.parseArguments')
+    def test_get_user_options_dynamic(self, parseArguments):
+        # Check the user options are generated after
+        # the command line options created in green.cmdline.parseArguments
+        store_opt = StoreOpt()
+        argparser = argparse.ArgumentParser()
+        store_opt(argparser.add_argument("-s", "--something", help="Something"))
+        store_opt(argparser.add_argument("--else", help="Else"))
+        store_opt(argparser.add_argument("-a", "--again", action="store_true", help="Again"))
+
+        args = argparser.parse_args([])
+        args.parser = argparser
+        args.store_opt = store_opt
+        parseArguments.return_value = args
+
+        options = command.get_user_options()
+
+        self.assertEqual(options, [
+            ('something=', 's', 'Something'),
+            ('else=', None, 'Else'),
+            ('again', 'a', 'Again'),
+        ])
+
+    def test_initialize_options(self):
+        d =  Distribution({'script_name': 'setup.py',
+                           'script_args': ['green']})
+
+        cmd = command.green(d)
+        for attr in ['completion_file', 'clear_omit', 'debug', 'processes']:
+            self.assertTrue(hasattr(cmd, attr), attr)
+
+    @patch('green.command.main', return_value=0)
+    def test_run(self, main):
+        d =  Distribution({'script_name': 'setup.py',
+                           'script_args': ['green'],
+                           'test_suite': 'green.test.test_version'})
+
+        cmd = command.green(d)
+        cmd.run()
+        main.assert_called_once_with(['green.test.test_version'])
+
+    @patch('green.command.main', return_value=125)
+    def test_run_exits(self, main):
+        d =  Distribution({'script_name': 'setup.py',
+                           'script_args': ['green']})
+
+        cmd = command.green(d)
+        with self.assertRaises(SystemExit) as se:
+            cmd.run()
+        self.assertEqual(se.exception.code, 125)

--- a/green/test/test_djangorunner.py
+++ b/green/test/test_djangorunner.py
@@ -137,7 +137,7 @@ class TestDjangoRunner(unittest.TestCase):
         test_command.test_runner = "green.djangorunner.DjangoRunner"
         parser = ArgumentParser()
         test_command.add_arguments(parser)
-        args = parser.parse_args()
+        args = parser.parse_args([])
         self.assertIn('verbosity', args)
 
     def test_check_default_verbosity(self):
@@ -154,7 +154,7 @@ class TestDjangoRunner(unittest.TestCase):
         test_command.test_runner = "green.djangorunner.DjangoRunner"
         parser = ArgumentParser()
         test_command.add_arguments(parser)
-        args = parser.parse_args()
+        args = parser.parse_args([])
         self.assertEqual(args.verbosity,-1)
 
     def test_run_with_verbosity_flag(self):

--- a/green/test/test_djangorunner.py
+++ b/green/test/test_djangorunner.py
@@ -137,7 +137,7 @@ class TestDjangoRunner(unittest.TestCase):
         test_command.test_runner = "green.djangorunner.DjangoRunner"
         parser = ArgumentParser()
         test_command.add_arguments(parser)
-        args = parser.parse_args([])
+        args = parser.parse_args()
         self.assertIn('verbosity', args)
 
     def test_check_default_verbosity(self):
@@ -154,7 +154,7 @@ class TestDjangoRunner(unittest.TestCase):
         test_command.test_runner = "green.djangorunner.DjangoRunner"
         parser = ArgumentParser()
         test_command.add_arguments(parser)
-        args = parser.parse_args([])
+        args = parser.parse_args()
         self.assertEqual(args.verbosity,-1)
 
     def test_run_with_verbosity_flag(self):

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,9 @@ setup(
             'green%d = green.cmdline:main' % sys.version_info[:1],    # green2 or green3
             'green%d.%d = green.cmdline:main' % sys.version_info[:2], # green3.4 etc.
             ],
+        'distutils.commands' : [
+            'green = green.command:green'
+        ]
     },
     test_suite='green.test',
     description = 'Green is a clean, colorful, fast python test runner.',


### PR DESCRIPTION
PR for #158.

Allows running green with `python setup.py green` by declaring a distutils command in `green.command`.

The list of arguments is the same as the arguments of the plain green CLI, as it is dynamically generated using the `StoreOpt` results.

I had to change the behaviour of `green.main` a bit, to make it possible to pass it a custom `argv`. The command only validates the input arguments, and then passes everything to `green.main`.

Since distutils commands cannot have positional arguments, I made it possible to specify a test target to use using the `test_suite` argument in the `setup.py`.