### PR TITLE
Unconditionally cleanup temp folder in poolRunner

### DIFF
--- a/green/process.py
+++ b/green/process.py
@@ -254,8 +254,7 @@ def poolRunner(target, queue, coverage_number=None, omit_patterns=[]):  # pragma
 
     def cleanup():
         # Restore the state of the temp directory
-        if sys.version_info[0] == 2: # pragma: no cover
-            shutil.rmtree(tempfile.tempdir, ignore_errors=True)
+        shutil.rmtree(tempfile.tempdir, ignore_errors=True)
         tempfile.tempdir = saved_tempdir
         queue.put(None)
         # Finish coverage

--- a/green/process.py
+++ b/green/process.py
@@ -254,7 +254,9 @@ def poolRunner(target, queue, coverage_number=None, omit_patterns=[]):  # pragma
 
     def cleanup():
         # Restore the state of the temp directory
-        shutil.rmtree(tempfile.tempdir, ignore_errors=True)
+        # TODO: Make this not necessary on macOS+Python3 (see #173)
+        if sys.platform != 'darwin' or sys.version_info[0] == 2:
+            shutil.rmtree(tempfile.tempdir, ignore_errors=True)
         tempfile.tempdir = saved_tempdir
         queue.put(None)
         # Finish coverage


### PR DESCRIPTION
Hi Nathan, 
because of a conditional branch the temporary directories that a `poolRunner` call creates are not properly created in Python 3. When running tests several times, the `/tmp` (or equivalent) directory can become cluttered very quickly. I removed the `if` branching so that the temporary folder is always removed.