### PR TITLE
setup.py's `test_suite` option must be a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ from setuptools import setup
 setup(
     ...
     setup_requires = ['green'],
-    # test_suite = ["my_project.tests"]
+    # test_suite = "my_project.tests"
 )
 ```
 


### PR DESCRIPTION
...not a list. At least for me (Windows 10, Python 3.6.4)