### PR TITLE
Use termstyle instead of python-termstyle

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 colorama
 coverage
 mock
-python-termstyle
+termstyle
 unidecode
 backports.shutil_get_terminal_size; python_version < '3.3'

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('README-pypi.rst') as readme_file:
 dependencies = [
     'colorama',
     'coverage',
-    'python-termstyle',
+    'termstyle',
     'unidecode',
 ]
 if sys.version_info[0] == 2:


### PR DESCRIPTION
Termstyle has version 0.1.11 instead of 0.1.10.