### PR TITLE
Fix `python setup.py --help-commands` not working

### DIFF
--- a/green/command.py
+++ b/green/command.py
@@ -13,8 +13,11 @@ from green.cmdline import main
 
 
 def get_user_options():
-    r = parseArguments()
 
+    if "--help-commands" in sys.argv:
+        return []
+
+    r = parseArguments()
     options = []
 
     for action in r.store_opt.actions:
@@ -29,7 +32,7 @@ def get_user_options():
 class green(Command):
 
     command_name = "green"
-    description = " green is a clean, colorful, fast python test runner"
+    description = "Run unit tests using green"
     user_options = get_user_options()
 
     def initialize_options(self):


### PR DESCRIPTION
With the current `green` version installed:
```
python setup.py --help-commands
usage: green [options] [target [target2 ...]]
green: error: unrecognized arguments: --help-commands
```

This is a mistake of mine, as generating the argument list for `green.command.green` actually parses the CLI arguments beforehand, and since it does not know `--help-commands`, the program crashes.

I also changed the description to be more in par with the other tools:

* `behave` description: `Run feature tests with behave`
* `nosetests` description: `Run unit tests using nosetests`

so I changed `green` description to `Run unit tests using green`.