### PR TITLE
djangorunner: Correct the config declaration.

### DIFF
--- a/green/djangorunner.py
+++ b/green/djangorunner.py
@@ -6,7 +6,7 @@ To try running Django tests using green you can run:
 
 To make the change permanent for your project, in settings.py add:
 
-    TEST_RUNNER=green.djangorunner.DjangoRunner
+    TEST_RUNNER="green.djangorunner.DjangoRunner"
 """
 
 from argparse import Namespace


### PR DESCRIPTION
Users who see this and copy/paste will receive an error, because the
configuration value in settings.py should be string and therefore enquoted.

Correct this docstring to reflect proper usage.
