### PR TITLE
Fixed handling of green 'verbose' Django args

### DIFF
--- a/green/djangorunner.py
+++ b/green/djangorunner.py
@@ -73,19 +73,19 @@ try:
 
     class DjangoRunner(DiscoverRunner):
 
-        def __init__(self, verbosity=-1, **kwargs):
+        def __init__(self, verbose=-1, **kwargs):
 
             super(DjangoRunner, self).__init__(**kwargs)
-            self.verbosity = verbosity
+            self.verbose = verbose
             self.loader = GreenTestLoader()
 
         @classmethod
         def add_arguments(cls, parser):
             parser.add_argument (
                     '--green-verbosity',
-                    action='store', dest='verbosity', default=-1, type=int,
+                    action='store', dest='verbose', default=-1, type=int,
                     help="""
-                    Green verbosity level for tests.  Value should be an integer
+                    Green 'verbose' level for tests.  Value should be an integer
                     that green supports.  For example: --green-verbosity 3""")
             super(DjangoRunner, cls).add_arguments(parser)
 
@@ -114,8 +114,8 @@ try:
                 test_labels = ['.']
 
             args = mergeConfig(Namespace())
-            if self.verbosity != -1:
-                args.verbosity = self.verbosity
+            if self.verbose != -1:
+                args.verbose = self.verbose
             args.targets = test_labels
             stream = GreenStream(sys.stdout)
             suite = self.loader.loadTargets(args.targets)

--- a/green/test/test_djangorunner.py
+++ b/green/test/test_djangorunner.py
@@ -135,7 +135,7 @@ class TestDjangoRunner(unittest.TestCase):
         parser = ArgumentParser()
         test_command.add_arguments(parser)
         args = parser.parse_args()
-        self.assertIn('verbosity', args)
+        self.assertIn('verbose', args)
 
     def test_check_default_verbosity(self):
         """
@@ -152,7 +152,7 @@ class TestDjangoRunner(unittest.TestCase):
         parser = ArgumentParser()
         test_command.add_arguments(parser)
         args = parser.parse_args()
-        self.assertEqual(args.verbosity,-1)
+        self.assertEqual(args.verbose,-1)
 
     def test_run_with_verbosity_flag(self):
         """
@@ -164,7 +164,7 @@ class TestDjangoRunner(unittest.TestCase):
         dr.setup_databases           = MagicMock()
         dr.teardown_databases        = MagicMock()
         dr.teardown_test_environment = MagicMock()
-        dr.verbosity = 2
+        dr.verbose = 2
         saved_loadTargets = dr.loader.loadTargets
         dr.loader.loadTargets = MagicMock()
         self.addCleanup(setattr, dr.loader, 'loadTargets',


### PR DESCRIPTION
Fixes the behaviour of Django Test Runner according to the Documentation.

 * 'verbosity' is a django thing and is parsed and handled by Django, 'verbose' is the green's labeling, before this fix the only wait to set the 'verbose' configuration while using django was via config file option.