### PR TITLE
Modified lines 321 and 322 to fix Issue # 176

### DIFF
--- a/green/loader.py
+++ b/green/loader.py
@@ -318,8 +318,8 @@ def toProtoTestList(suite, test_list=None, doing_completions=False):
     if suite.__class__.__name__ == 'ModuleImportFailure':
         if doing_completions:
             return test_list
-        exception_method = str(suite).split()[0]
-        getattr(suite, exception_method)()
+        exception_method = str(suite).split('(')[0]
+        getattr(suite, exception_method.strip())()
     # On to the real stuff
     if isinstance(suite, unittest.TestCase):
         # Skip actual blank TestCase objects that twisted inserts

--- a/green/test/test_loader.py
+++ b/green/test/test_loader.py
@@ -24,7 +24,7 @@ class TestToProtoTestList(unittest.TestCase):
         """
         suite = MagicMock()
         suite.__class__.__name__ = str('ModuleImportFailure')
-        suite.__str__.return_value = "exception_method other_stuff"
+        suite.__str__.return_value = "exception_method (other_stuff)"
         suite.exception_method.side_effect = AttributeError
         self.assertRaises(AttributeError, loader.toProtoTestList, (suite,))
 


### PR DESCRIPTION
In recreating the problem I have found that if there is an import error the 'ModuleImportFailure' gets triggered, and exception_method returns a string that splits at the first space, and if a windows path has a space this causes the bug.

The discover option will go through more directories than unittest, which can possibly try to run tests that weren't expected/wanted, and lead to not knowing where the import error could be caused.

EX:

my project\
    	|_my_project.py
    	|
    	|_tests\
    	|     |_test_this.py
    	|
    	|_side_project\
    	|            |_fancy_side_project_with_import_error.py
   	|	     |
	|	     |_tests\
	|	     	   |_test_side_project.py

when green is run in "my project" the error message will be:
AttributeError: 'ModuleImportFailure' object has no attribute 'my'

My solution is to split on the "(" in the suite string and to strip remaining white-space on the end. This will give the full file path where the error is and shouldn't change any other functionality.

I did have to change one test to make it pass because their was no "(" to split on, but in my manual testing of the error the "suite" object always has the parenthesis, so I felt this was needed. I don't know if this will affect anything on different operating systems