### PR TITLE
Run all tests in the dedicated temp dir

### DIFF
--- a/green/process.py
+++ b/green/process.py
@@ -291,12 +291,6 @@ def poolRunner(
 
     def cleanup():
         # Restore the state of the temp directory
-        # TODO: Make this not necessary on macOS+Python3 (see #173)
-        if sys.version_info[0] == 2:
-            try:
-                shutil.rmtree(tempfile.tempdir, ignore_errors=True)
-            except:
-                pass
         tempfile.tempdir = saved_tempdir
         queue.put(None)
         # Finish coverage


### PR DESCRIPTION
Run all tests in the dedicated temp dir, which is auto-deleted at the end. The individual test processes create their own temps as subdirectories under this temp dir.
