### PR TITLE
Fix "1A" appearing at the start of result lines in CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 - Properly clean up temporary files in some versions/platforms. Contributed by @Icerman in #232.
   Resolves #228.
+- Fix an unwanted "1A" appearing at the beginning of test result lines in CI such as GitHub Actions
+  and AppVeyor.
 
 # Version 3.2.2
 #### 22 Sep 2020

--- a/green/output.py
+++ b/green/output.py
@@ -51,7 +51,7 @@ class Colors:
 
     # Movement
     def start_of_line(self):
-        return "\r"
+        return "TESTING"
 
     def up(self, lines=1):
         return Cursor.UP(lines)

--- a/green/output.py
+++ b/green/output.py
@@ -51,7 +51,7 @@ class Colors:
 
     # Movement
     def start_of_line(self):
-        return "TESTING"
+        return "\r"
 
     def up(self, lines=1):
         return Cursor.UP(lines)

--- a/green/result.py
+++ b/green/result.py
@@ -587,19 +587,15 @@ class GreenTestResult(BaseTestResult):
                 self.stream.write(self.colors.start_of_line())
             # Can end up being different from the first time due to subtest
             # information only being available after a test result comes in.
-            print(1)
             second_text_output = self.stream.formatLine(
                 test.getDescription(self.verbose), indent=2, outcome_char=outcome_char
             )
-            print(2)
-            if terminal_width:  # pragma: no cover
+            if self.stream.isatty() and terminal_width:  # pragma: no cover
                 cursor_rewind = (
                     int(ceil(float(len(self.first_text_output)) / terminal_width)) - 1
                 )
                 if cursor_rewind:
-                    print("terminal width {}".format(terminal_width))
                     self.stream.write(self.colors.up(cursor_rewind))
-            print(4)
             self.stream.write(color_func(second_text_output))
             if reason:
                 self.stream.write(color_func(" -- " + reason))

--- a/green/result.py
+++ b/green/result.py
@@ -597,7 +597,7 @@ class GreenTestResult(BaseTestResult):
                     int(ceil(float(len(self.first_text_output)) / terminal_width)) - 1
                 )
                 if cursor_rewind:
-                    print(3)
+                    print("terminal width {}".format(terminal_width))
                     self.stream.write(self.colors.up(cursor_rewind))
             print(4)
             self.stream.write(color_func(second_text_output))

--- a/green/result.py
+++ b/green/result.py
@@ -587,15 +587,19 @@ class GreenTestResult(BaseTestResult):
                 self.stream.write(self.colors.start_of_line())
             # Can end up being different from the first time due to subtest
             # information only being available after a test result comes in.
+            print(1)
             second_text_output = self.stream.formatLine(
                 test.getDescription(self.verbose), indent=2, outcome_char=outcome_char
             )
+            print(2)
             if terminal_width:  # pragma: no cover
                 cursor_rewind = (
                     int(ceil(float(len(self.first_text_output)) / terminal_width)) - 1
                 )
                 if cursor_rewind:
+                    print(3)
                     self.stream.write(self.colors.up(cursor_rewind))
+            print(4)
             self.stream.write(color_func(second_text_output))
             if reason:
                 self.stream.write(color_func(" -- " + reason))


### PR DESCRIPTION
Time to _finally_ find and fix that annoying "1A" that appears before each result line in AppVeyor and GitHub actions.