### PR TITLE
[WIP] Watch feature

### DIFF
--- a/green/cmdline.py
+++ b/green/cmdline.py
@@ -8,6 +8,7 @@ import green.config as config
 
 
 def _main(argv, testing):
+    original_argv = sys.argv
     args = config.parseArguments(argv)
     args = config.mergeConfig(args, testing)
 
@@ -31,6 +32,9 @@ def _main(argv, testing):
 
     if args.debug:
         green.output.debug_level = args.debug
+
+    if args.watch:
+        return watch(original_argv, args)
 
     stream = GreenStream(sys.stdout, disable_windows=args.disable_windows)
 
@@ -64,9 +68,6 @@ def _main(argv, testing):
     if not test_suite:
         debug("No test loading attempts succeeded.  Created an empty test suite.")
         test_suite = GreenTestSuite()
-
-    if args.watch:
-        watch(stream, args, testing)
 
     # Actually run the test_suite
     result = run(test_suite, stream, args, testing)

--- a/green/cmdline.py
+++ b/green/cmdline.py
@@ -25,6 +25,7 @@ def _main(argv, testing):
     from green.output import GreenStream, debug
     import green.output
     from green.suite import GreenTestSuite
+    from green.watch import watch
 
     GreenTestSuite.args = args
 
@@ -63,6 +64,9 @@ def _main(argv, testing):
     if not test_suite:
         debug("No test loading attempts succeeded.  Created an empty test suite.")
         test_suite = GreenTestSuite()
+
+    if args.watch:
+        watch(stream, args, testing)
 
     # Actually run the test_suite
     result = run(test_suite, stream, args, testing)

--- a/green/config.py
+++ b/green/config.py
@@ -50,6 +50,7 @@ default_args = argparse.Namespace(  # pragma: no cover
     file_pattern="test*.py",
     test_pattern="*",
     junit_report="",
+    watch=False,
     run_coverage=False,
     cov_config_file=True,  # A string with a special boolean default
     quiet_coverage=False,
@@ -407,6 +408,15 @@ def parseArguments(argv=None):  # pragma: no cover
             default=argparse.SUPPRESS,
         )
     )
+    store_opt(
+        other_args.add_argument(
+            "-w",
+            "--watch",
+            action="store_true",
+            help=("Watch for file changes and re-run tests."),
+            default=argparse.SUPPRESS,
+        )
+    )
 
     cov_args = parser.add_argument_group(
         "Coverage Options ({})".format(coverage_version)
@@ -675,6 +685,7 @@ def mergeConfig(args, testing=False):  # pragma: no cover
             "version",
             "disable_unidecode",
             "failfast",
+            "watch",
             "run_coverage",
             "options",
             "completions",

--- a/green/watch.py
+++ b/green/watch.py
@@ -1,0 +1,46 @@
+import time
+from watchdog.observers import Observer
+from watchdog.events import FileSystemEventHandler
+
+from green.runner import run
+from green.loader import GreenTestLoader
+
+to_run = True
+
+
+class GreenEventHandler(FileSystemEventHandler):
+    def __init__(self):
+        super().__init__()
+
+    def on_any_event(self, event):
+        global to_run
+        to_run = True
+
+
+def watch(stream, args, testing):
+    global to_run
+    event_handler = GreenEventHandler()
+
+    observer = Observer()
+    observer.schedule(event_handler, '.', recursive=True)
+    observer.start()
+
+    last_result = None
+
+    try:
+        while True:
+            if to_run:
+                loader = GreenTestLoader()
+                test_suite = loader.loadTargets(
+                    args.targets, file_pattern=args.file_pattern)
+
+                last_result = run(test_suite, stream, args, testing)
+                to_run = False
+
+            time.sleep(1)
+    except KeyboardInterrupt:
+        observer.stop()
+
+    observer.join()
+
+    return last_result

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,3 +1,4 @@
 django
 testtools
+watchdog
 -r requirements.txt


### PR DESCRIPTION
Closes #246. 

Hey @CleanCut! I've had some time to give this a go, but I need some advice as I'm running into some issues. 

The current problem is that on file save, the tests successfully re-run, however it is re-run on the old code. It appears that it does not load in the newer, just saved code. 

The implementation used to watch file changes is the [watchdog](https://github.com/gorakhargosh/watchdog) library that is cross-platform compatible, but I understand it brings in a new dependency which you may not want. I also wasn't sure how to add it to the requirements.txt file, as the usual `pip3 freeze > requirements.txt` ended up changing pretty much the whole file...!

I wanted to re-run the tests inside the `GreenEventHandler` I wrote, however I ran into issues with `signal` not being able to run outside of the main thread. Therefore I went with a simple global semaphore implementation as I'm not sure how else to deal with this!

I'm still fairly new to contributing to larger projects, but I'm happy to put in the time and to learn if you can point me in the right direction!