### PR TITLE
Fix UserWarning in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
When installing `green` in Python 3.10 with `setuptools-62.4.0`, I am getting the following error:

```sh
UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead
```

It looks like dashes were deprecated in version 54.1.0 of `setuptools`.