### PR TITLE
docs: Fix a few typos

### DIFF
--- a/green/loader.py
+++ b/green/loader.py
@@ -37,7 +37,7 @@ class GreenTestLoader(unittest.TestLoader):
         test_case_names = list(filter(filter_test_methods, dir(testCaseClass)))
         debug("Test case names: {}".format(test_case_names))
 
-        # Use default unittest.TestSuite sorting method if not overriden
+        # Use default unittest.TestSuite sorting method if not overridden
         test_case_names.sort(key=functools.cmp_to_key(self.sortTestMethodsUsing))
 
         if not test_case_names and hasattr(testCaseClass, "runTest"):
@@ -479,7 +479,7 @@ def flattenTestSuite(test_suite, module=None):
         suite.injected_module = module.__name__
         suites.append(suite)
 
-    # Now extract all tests from the suite heirarchies and flatten them into a
+    # Now extract all tests from the suite hierarchies and flatten them into a
     # single suite with all tests.
     tests = []
     for suite in suites:

--- a/green/output.py
+++ b/green/output.py
@@ -104,7 +104,7 @@ class Colors:
 
 class GreenStream(object):
     """
-    Wraps a stream-like object with the following additonal features:
+    Wraps a stream-like object with the following additional features:
 
     1) A handy writeln() method (which calls write() under-the-hood)
     2) Handy formatLine() and formatText() methods, which support indent

--- a/green/result.py
+++ b/green/result.py
@@ -356,7 +356,7 @@ class ProtoTestResult(BaseTestResult):
 
     def addExpectedFailure(self, test, err):
         """
-        Called when a test fails, and we expeced the failure
+        Called when a test fails, and we expected the failure
         """
         self.expectedFailures.append((proto_test(test), proto_error(err)))
 


### PR DESCRIPTION
There are small typos in:
- green/loader.py
- green/output.py
- green/result.py

Fixes:
- Should read `overridden` rather than `overriden`.
- Should read `hierarchies` rather than `heirarchies`.
- Should read `expected` rather than `expeced`.
- Should read `additional` rather than `additonal`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md