### PR TITLE
Drop code that explicitly supported python 2.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
       fail-fast: false
 
     steps:
@@ -32,7 +32,7 @@ jobs:
         run: |
           pip install --upgrade black
           black --check --diff green
-        if: matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest'
+        if: matrix.python-version == '3.11' && matrix.os == 'ubuntu-latest'
 
       - name: Test
         run: python -m green.cmdline -tvvvv green
@@ -41,10 +41,10 @@ jobs:
         run: |
           pip install --upgrade coveralls
           ./g -tvvvvr green
-        if: matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest'
+        if: matrix.python-version == '3.11' && matrix.os == 'ubuntu-latest'
 
       - name: Coveralls
         run: coveralls --service=github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest'
+        if: matrix.python-version == '3.11' && matrix.os == 'ubuntu-latest'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Unreleased
 #### Date TBD
 
+- Drop Python 2 support.
+- Run black 23.1.2 on the code to apply the newest style.
+- Add Python 3.11 to the CI Action.
+
 # Version 3.4.3
 #### 20 Sep 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 #### Date TBD
 
 - Drop Python 2 support.
-- Run black 23.1.2 on the code to apply the newest style.
 - Add Python 3.11 to the CI Action.
 
 # Version 3.4.3

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Features
 - **Convenient** - Bash-completion and ZSH-completion of options and test targets.
 - **Thorough** - Built-in integration with [coverage](http://nedbatchelder.com/code/coverage/).
 - **Embedded** - Can be run with a setup command without in-site installation.
-- **Modern** - Supports Python 3.5+. Additionally, [PyPy](http://pypy.org) is supported on a best-effort basis. Python 2 is no longer supported.  
+- **Modern** - Supports Python 3.5+. Additionally, [PyPy](http://pypy.org) is supported on a best-effort basis.
 - **Portable** - macOS, Linux, and BSDs are fully supported.  Windows is supported on a best-effort basis.
 - **Living** - This project grows and changes.  See the
   [changelog](https://github.com/CleanCut/green/blob/main/CHANGELOG.md)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Features
 - **Convenient** - Bash-completion and ZSH-completion of options and test targets.
 - **Thorough** - Built-in integration with [coverage](http://nedbatchelder.com/code/coverage/).
 - **Embedded** - Can be run with a setup command without in-site installation.
-- **Modern** - Supports Python 3.5+. Additionally, [PyPy](http://pypy.org) is supported on a best-effort basis.
+- **Modern** - Supports Python 3.5+. Additionally, [PyPy](http://pypy.org) is supported on a best-effort basis. Python 2 is no longer supported.  
 - **Portable** - macOS, Linux, and BSDs are fully supported.  Windows is supported on a best-effort basis.
 - **Living** - This project grows and changes.  See the
   [changelog](https://github.com/CleanCut/green/blob/main/CHANGELOG.md)

--- a/example/proj/foo.py
+++ b/example/proj/foo.py
@@ -13,7 +13,7 @@ class School:
         >>> s.food()
         'awful'
         """
-        return 'awful'
+        return "awful"
 
     def age(self):
         return 300

--- a/example/proj/foo.py
+++ b/example/proj/foo.py
@@ -5,8 +5,8 @@ def answer():
     """
     return 42
 
-class School():
 
+class School:
     def food(self):
         """
         >>> s = School()

--- a/example/proj/test/test_foo.py
+++ b/example/proj/test/test_foo.py
@@ -17,8 +17,8 @@ from proj.foo import answer, School
 
 # Then write your tests
 
-class TestAnswer(unittest.TestCase):
 
+class TestAnswer(unittest.TestCase):
     def test_type(self):
         "answer() returns an integer"
         self.assertEqual(type(answer()), int)
@@ -27,8 +27,8 @@ class TestAnswer(unittest.TestCase):
         "answer() returns 42"
         self.assertEqual(answer(), 42)
 
-class TestSchool(unittest.TestCase):
 
+class TestSchool(unittest.TestCase):
     def test_food(self):
         school = School()
         self.assertEqual(school.food(), 'awful')
@@ -36,6 +36,7 @@ class TestSchool(unittest.TestCase):
     def test_age(self):
         school = School()
         self.assertEqual(school.age(), 300)
+
 
 # If there are doctests you would like to run, add a `doctest_modules` list to
 # the top level of any of your test modules.  Items in the list are modules to

--- a/example/proj/test/test_foo.py
+++ b/example/proj/test/test_foo.py
@@ -31,7 +31,7 @@ class TestAnswer(unittest.TestCase):
 class TestSchool(unittest.TestCase):
     def test_food(self):
         school = School()
-        self.assertEqual(school.food(), 'awful')
+        self.assertEqual(school.food(), "awful")
 
     def test_age(self):
         school = School()

--- a/green/__init__.py
+++ b/green/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from .version import __version__
 
 __version__

--- a/green/__main__.py
+++ b/green/__main__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import sys
 
 from .cmdline import main

--- a/green/cmdline.py
+++ b/green/cmdline.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 import os
 import sys
 import tempfile

--- a/green/command.py
+++ b/green/command.py
@@ -1,6 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-
 import sys
 
 try:

--- a/green/command.py
+++ b/green/command.py
@@ -10,7 +10,6 @@ from green.cmdline import main
 
 
 def get_user_options():
-
     # When running "python setup.py --help-commands", setup.py will call this
     # function -- but green isn't actually being called.
     if "--help-commands" in sys.argv:
@@ -31,7 +30,6 @@ def get_user_options():
 
 
 class green(Command):
-
     command_name = "green"
     description = "Run unit tests using green"
     user_options = get_user_options()

--- a/green/config.py
+++ b/green/config.py
@@ -420,7 +420,9 @@ def parseArguments(argv=None):  # pragma: no cover
         )
     )
 
-    cov_args = parser.add_argument_group("Coverage Options ({})".format(coverage_version))
+    cov_args = parser.add_argument_group(
+        "Coverage Options ({})".format(coverage_version)
+    )
     store_opt(
         cov_args.add_argument(
             "-r",

--- a/green/config.py
+++ b/green/config.py
@@ -1,6 +1,3 @@
-from __future__ import unicode_literals  # pragma: no cover
-from __future__ import print_function  # pragma: no cover
-
 # We have to use this entire file before we can turn coverage on, so we exclude
 # it from coverage.  We still have tests, though!
 

--- a/green/config.py
+++ b/green/config.py
@@ -420,9 +420,7 @@ def parseArguments(argv=None):  # pragma: no cover
         )
     )
 
-    cov_args = parser.add_argument_group(
-        "Coverage Options ({})".format(coverage_version)
-    )
+    cov_args = parser.add_argument_group("Coverage Options ({})".format(coverage_version))
     store_opt(
         cov_args.add_argument(
             "-r",

--- a/green/djangorunner.py
+++ b/green/djangorunner.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 """
 To try running Django tests using green you can run:
 

--- a/green/djangorunner.py
+++ b/green/djangorunner.py
@@ -73,7 +73,6 @@ try:
 
     class DjangoRunner(DiscoverRunner):
         def __init__(self, verbose=-1, **kwargs):
-
             super(DjangoRunner, self).__init__(**kwargs)
             self.verbose = verbose
             self.loader = GreenTestLoader()

--- a/green/examples.py
+++ b/green/examples.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 import sys
 import unittest
 

--- a/green/exceptions.py
+++ b/green/exceptions.py
@@ -1,5 +1,2 @@
-from __future__ import unicode_literals
-
-
 class InitializerOrFinalizerError(Exception):
     pass

--- a/green/junit.py
+++ b/green/junit.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from lxml.etree import Element, SubElement, tostring as to_xml
 
 

--- a/green/loader.py
+++ b/green/loader.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from collections import OrderedDict
 from doctest import DocTestCase, DocTestSuite
 from fnmatch import fnmatch

--- a/green/loader.py
+++ b/green/loader.py
@@ -94,7 +94,9 @@ class GreenTestLoader(unittest.TestLoader):
     if sys.version_info >= (3, 5):  # pragma: no cover
 
         def loadTestsFromModule(self, module, pattern=None):
-            tests = super(GreenTestLoader, self).loadTestsFromModule(module, pattern=pattern)
+            tests = super(GreenTestLoader, self).loadTestsFromModule(
+                module, pattern=pattern
+            )
             return flattenTestSuite(tests, module)
 
     else:  # pragma: no cover
@@ -187,7 +189,11 @@ class GreenTestLoader(unittest.TestLoader):
         return flattenTestSuite(suites) if suites else None
 
     def loadTarget(self, target, file_pattern="test*.py"):
-        debug("Attempting to load target '{}' with file_pattern '{}'".format(target, file_pattern))
+        debug(
+            "Attempting to load target '{}' with file_pattern '{}'".format(
+                target, file_pattern
+            )
+        )
 
         # For a test loader, we want to always the current working directory to
         # be the first item in sys.path, just like when a python interpreter is
@@ -423,7 +429,9 @@ def isPackage(file_path):
     """
     Determine whether or not a given path is a (sub)package or not.
     """
-    return os.path.isdir(file_path) and os.path.isfile(os.path.join(file_path, "__init__.py"))
+    return os.path.isdir(file_path) and os.path.isfile(
+        os.path.join(file_path, "__init__.py")
+    )
 
 
 def findDottedModuleAndParentDir(file_path):

--- a/green/loader.py
+++ b/green/loader.py
@@ -20,7 +20,6 @@ python_dir_pattern = re.compile(r"^[_a-z]\w*?$", re.IGNORECASE)
 
 
 class GreenTestLoader(unittest.TestLoader):
-
     suiteClass = GreenTestSuite
 
     def loadTestsFromTestCase(self, testCaseClass):
@@ -95,9 +94,7 @@ class GreenTestLoader(unittest.TestLoader):
     if sys.version_info >= (3, 5):  # pragma: no cover
 
         def loadTestsFromModule(self, module, pattern=None):
-            tests = super(GreenTestLoader, self).loadTestsFromModule(
-                module, pattern=pattern
-            )
+            tests = super(GreenTestLoader, self).loadTestsFromModule(module, pattern=pattern)
             return flattenTestSuite(tests, module)
 
     else:  # pragma: no cover
@@ -190,11 +187,7 @@ class GreenTestLoader(unittest.TestLoader):
         return flattenTestSuite(suites) if suites else None
 
     def loadTarget(self, target, file_pattern="test*.py"):
-        debug(
-            "Attempting to load target '{}' with file_pattern '{}'".format(
-                target, file_pattern
-            )
-        )
+        debug("Attempting to load target '{}' with file_pattern '{}'".format(target, file_pattern))
 
         # For a test loader, we want to always the current working directory to
         # be the first item in sys.path, just like when a python interpreter is
@@ -430,9 +423,7 @@ def isPackage(file_path):
     """
     Determine whether or not a given path is a (sub)package or not.
     """
-    return os.path.isdir(file_path) and os.path.isfile(
-        os.path.join(file_path, "__init__.py")
-    )
+    return os.path.isdir(file_path) and os.path.isfile(os.path.join(file_path, "__init__.py"))
 
 
 def findDottedModuleAndParentDir(file_path):

--- a/green/output.py
+++ b/green/output.py
@@ -128,9 +128,7 @@ class GreenStream(object):
         # win32 system calls for colors, but it WILL interpret posix ansi escape codes! (The
         # opposite of an actual windows command prompt)
         on_windows = platform.system() == "Windows"
-        on_windows_ci = os.environ.get("GITHUB_ACTIONS", False) or os.environ.get(
-            "APPVEYOR", False
-        )
+        on_windows_ci = os.environ.get("GITHUB_ACTIONS", False) or os.environ.get("APPVEYOR", False)
 
         if override_appveyor or (
             (on_windows and not on_windows_ci) and not disable_windows

--- a/green/output.py
+++ b/green/output.py
@@ -128,7 +128,9 @@ class GreenStream(object):
         # win32 system calls for colors, but it WILL interpret posix ansi escape codes! (The
         # opposite of an actual windows command prompt)
         on_windows = platform.system() == "Windows"
-        on_windows_ci = os.environ.get("GITHUB_ACTIONS", False) or os.environ.get("APPVEYOR", False)
+        on_windows_ci = os.environ.get("GITHUB_ACTIONS", False) or os.environ.get(
+            "APPVEYOR", False
+        )
 
         if override_appveyor or (
             (on_windows and not on_windows_ci) and not disable_windows

--- a/green/output.py
+++ b/green/output.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from colorama import init, deinit, Fore, Style
 from colorama.ansi import Cursor
 from colorama.initialise import wrap_stream
@@ -12,11 +11,8 @@ from unidecode import unidecode
 global debug_level
 debug_level = 0
 
-if sys.version_info[0] == 3:  # pragma: no cover
-    text_type = str
-    unicode = None  # so pyflakes stops complaining
-else:  # pragma: no cover
-    text_type = unicode
+text_type = str
+unicode = None  # so pyflakes stops complaining
 
 
 def debug(message, level=1):

--- a/green/process.py
+++ b/green/process.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 import logging
 import multiprocessing
 from multiprocessing.pool import Pool, RUN, TERMINATE
@@ -219,36 +218,9 @@ LoggingDaemonlessPool = LoggingDaemonlessPool38
 if tuple(map(int, platform.python_version_tuple()[:2])) < (3, 8):  # pragma: no cover
     LoggingDaemonlessPool = LoggingDaemonlessPool37
 
-import platform
 import multiprocessing.pool
 from multiprocessing import util
-
-try:
-    from multiprocessing.pool import MaybeEncodingError
-except:  # pragma: no cover
-    # Python 2.7.4 introduced this class.  If we're on Python 2.7.0 to 2.7.3
-    # then we'll have to define it ourselves. :-/
-    class MaybeEncodingError(Exception):
-        """Wraps possible unpickleable errors, so they can be
-        safely sent through the socket."""
-
-        def __init__(self, exc, value):
-            self.exc = repr(exc)
-            self.value = repr(value)
-            super(MaybeEncodingError, self).__init__(self.exc, self.value)
-
-        def __str__(self):
-            return "Error sending result: '%s'. Reason: '%s'" % (self.value, self.exc)
-
-        def __repr__(self):
-            return "<MaybeEncodingError: %s>" % str(self)
-
-
-# Python 2 and 3 raise a different error when they exit
-if platform.python_version_tuple()[0] == "2":  # pragma: no cover
-    PortableOSError = IOError
-else:  # pragma: no cover
-    PortableOSError = OSError
+from multiprocessing.pool import MaybeEncodingError
 
 
 def worker(
@@ -278,7 +250,7 @@ def worker(
     while maxtasks is None or (maxtasks and completed < maxtasks):
         try:
             task = get()
-        except (EOFError, PortableOSError):
+        except (EOFError, OSError):
             util.debug("worker got EOFError or OSError -- exiting")
             break
 

--- a/green/process.py
+++ b/green/process.py
@@ -136,9 +136,7 @@ class LoggingDaemonlessPool38(Pool):
         return process
 
     def apply_async(self, func, args=(), kwds={}, callback=None, error_callback=None):
-        return Pool.apply_async(
-            self, ProcessLogger(func), args, kwds, callback, error_callback
-        )
+        return Pool.apply_async(self, ProcessLogger(func), args, kwds, callback, error_callback)
 
     _wrap_exception = True
 
@@ -356,9 +354,7 @@ def poolRunner(
     # Each pool starts its own coverage, later combined by the main process.
     if coverage_number:
         cov = coverage.coverage(
-            data_file=".coverage.{}_{}".format(
-                coverage_number, random.randint(0, 10000)
-            ),
+            data_file=".coverage.{}_{}".format(coverage_number, random.randint(0, 10000)),
             omit=omit_patterns,
             config_file=cov_config_file,
         )
@@ -418,9 +414,7 @@ def poolRunner(
                     result.stopTest(test)
                     queue.put(result)
                 except:
-                    raise_internal_failure(
-                        "Green encountered an error when running the test."
-                    )
+                    raise_internal_failure("Green encountered an error when running the test.")
                     return
     else:
         # loadTargets() returned an object without a run() method, probably
@@ -439,9 +433,7 @@ def poolRunner(
         t.module = ".".join(target_list[:-2]) if len(target_list) > 1 else target
         t.class_name = target.split(".")[-2] if len(target_list) > 1 else "UnknownClass"
         t.description = description
-        t.method_name = (
-            target.split(".")[-1] if len(target_list) > 1 else "unknown_method"
-        )
+        t.method_name = target.split(".")[-1] if len(target_list) > 1 else "unknown_method"
         result.startTest(t)
         result.addError(t, err)
         result.stopTest(t)

--- a/green/process.py
+++ b/green/process.py
@@ -136,7 +136,9 @@ class LoggingDaemonlessPool38(Pool):
         return process
 
     def apply_async(self, func, args=(), kwds={}, callback=None, error_callback=None):
-        return Pool.apply_async(self, ProcessLogger(func), args, kwds, callback, error_callback)
+        return Pool.apply_async(
+            self, ProcessLogger(func), args, kwds, callback, error_callback
+        )
 
     _wrap_exception = True
 
@@ -354,7 +356,9 @@ def poolRunner(
     # Each pool starts its own coverage, later combined by the main process.
     if coverage_number:
         cov = coverage.coverage(
-            data_file=".coverage.{}_{}".format(coverage_number, random.randint(0, 10000)),
+            data_file=".coverage.{}_{}".format(
+                coverage_number, random.randint(0, 10000)
+            ),
             omit=omit_patterns,
             config_file=cov_config_file,
         )
@@ -414,7 +418,9 @@ def poolRunner(
                     result.stopTest(test)
                     queue.put(result)
                 except:
-                    raise_internal_failure("Green encountered an error when running the test.")
+                    raise_internal_failure(
+                        "Green encountered an error when running the test."
+                    )
                     return
     else:
         # loadTargets() returned an object without a run() method, probably
@@ -433,7 +439,9 @@ def poolRunner(
         t.module = ".".join(target_list[:-2]) if len(target_list) > 1 else target
         t.class_name = target.split(".")[-2] if len(target_list) > 1 else "UnknownClass"
         t.description = description
-        t.method_name = target.split(".")[-1] if len(target_list) > 1 else "unknown_method"
+        t.method_name = (
+            target.split(".")[-1] if len(target_list) > 1 else "unknown_method"
+        )
         result.startTest(t)
         result.addError(t, err)
         result.stopTest(t)

--- a/green/result.py
+++ b/green/result.py
@@ -1,10 +1,8 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-
 from collections import OrderedDict
 from doctest import DocTestCase
 from io import StringIO
 from math import ceil
+from shutil import get_terminal_size
 import sys
 import time
 import traceback
@@ -14,11 +12,6 @@ from unittest import TestCase
 from green.output import Colors, debug
 from green.version import pretty_version
 
-# introduced in Python 3
-try:
-    from shutil import get_terminal_size
-except ImportError:  # pragma: no cover
-    from backports.shutil_get_terminal_size import get_terminal_size
 
 terminal_width, _ignored = get_terminal_size()
 

--- a/green/result.py
+++ b/green/result.py
@@ -109,14 +109,7 @@ class ProtoTest:
     def dotted_name(self, ignored=None):
         if self.is_doctest or self.is_class_or_module_teardown_error:
             return self.name
-        return (
-            self.module
-            + "."
-            + self.class_name
-            + "."
-            + self.method_name
-            + self.subtest_part
-        )
+        return self.module + "." + self.class_name + "." + self.method_name + self.subtest_part
 
     def getDescription(self, verbose):
         # Classes or module teardown errors
@@ -509,9 +502,7 @@ class GreenTestResult(BaseTestResult):
             self.stream.writeln()
         if self.shouldStop:
             self.stream.writeln()
-            self.stream.writeln(
-                self.colors.yellow("Warning: Some tests may not have been run.")
-            )
+            self.stream.writeln(self.colors.yellow("Warning: Some tests may not have been run."))
             self.stream.writeln()
         self.stream.writeln(
             "Ran %s test%s in %ss using %s process%s"
@@ -565,9 +556,7 @@ class GreenTestResult(BaseTestResult):
             # Class...if it changed.
             if current_class != self.last_class:
                 self.stream.writeln(
-                    self.colors.className(
-                        self.stream.formatText(current_class, indent=1)
-                    )
+                    self.colors.className(self.stream.formatText(current_class, indent=1))
                 )
             if self.stream.isatty():
                 # In the terminal, we will write a placeholder, and then
@@ -603,9 +592,7 @@ class GreenTestResult(BaseTestResult):
                 test.getDescription(self.verbose), indent=2, outcome_char=outcome_char
             )
             if self.stream.isatty() and terminal_width:  # pragma: no cover
-                cursor_rewind = (
-                    int(ceil(float(len(self.first_text_output)) / terminal_width)) - 1
-                )
+                cursor_rewind = int(ceil(float(len(self.first_text_output)) / terminal_width)) - 1
                 if cursor_rewind:
                     self.stream.write(self.colors.up(cursor_rewind))
             self.stream.write(color_func(second_text_output))
@@ -721,7 +708,7 @@ class GreenTestResult(BaseTestResult):
                     self.displayStderr(test)
 
         # Actual tracebacks and captured output for failing tests
-        for (test, color_func, outcome, err) in self.all_errors:
+        for test, color_func, outcome, err in self.all_errors:
             # Header Line
             self.stream.writeln(
                 "\n" + color_func(outcome) + " in " + self.colors.bold(test.dotted_name)

--- a/green/result.py
+++ b/green/result.py
@@ -109,7 +109,14 @@ class ProtoTest:
     def dotted_name(self, ignored=None):
         if self.is_doctest or self.is_class_or_module_teardown_error:
             return self.name
-        return self.module + "." + self.class_name + "." + self.method_name + self.subtest_part
+        return (
+            self.module
+            + "."
+            + self.class_name
+            + "."
+            + self.method_name
+            + self.subtest_part
+        )
 
     def getDescription(self, verbose):
         # Classes or module teardown errors
@@ -502,7 +509,9 @@ class GreenTestResult(BaseTestResult):
             self.stream.writeln()
         if self.shouldStop:
             self.stream.writeln()
-            self.stream.writeln(self.colors.yellow("Warning: Some tests may not have been run."))
+            self.stream.writeln(
+                self.colors.yellow("Warning: Some tests may not have been run.")
+            )
             self.stream.writeln()
         self.stream.writeln(
             "Ran %s test%s in %ss using %s process%s"
@@ -556,7 +565,9 @@ class GreenTestResult(BaseTestResult):
             # Class...if it changed.
             if current_class != self.last_class:
                 self.stream.writeln(
-                    self.colors.className(self.stream.formatText(current_class, indent=1))
+                    self.colors.className(
+                        self.stream.formatText(current_class, indent=1)
+                    )
                 )
             if self.stream.isatty():
                 # In the terminal, we will write a placeholder, and then
@@ -592,7 +603,9 @@ class GreenTestResult(BaseTestResult):
                 test.getDescription(self.verbose), indent=2, outcome_char=outcome_char
             )
             if self.stream.isatty() and terminal_width:  # pragma: no cover
-                cursor_rewind = int(ceil(float(len(self.first_text_output)) / terminal_width)) - 1
+                cursor_rewind = (
+                    int(ceil(float(len(self.first_text_output)) / terminal_width)) - 1
+                )
                 if cursor_rewind:
                     self.stream.write(self.colors.up(cursor_rewind))
             self.stream.write(color_func(second_text_output))

--- a/green/runner.py
+++ b/green/runner.py
@@ -28,7 +28,9 @@ class InitializerOrFinalizer:
             return
         try:
             __import__(self.module_part)
-            loaded_function = getattr(modules[self.module_part], self.function_part, None)
+            loaded_function = getattr(
+                modules[self.module_part], self.function_part, None
+            )
         except Exception as e:
             raise InitializerOrFinalizerError(
                 "Couldn't load '{}' - got: {}".format(self.function_part, str(e))

--- a/green/runner.py
+++ b/green/runner.py
@@ -1,6 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-
 import multiprocessing
 from sys import modules
 from unittest.signals import registerResult, installHandler, removeResult

--- a/green/runner.py
+++ b/green/runner.py
@@ -28,9 +28,7 @@ class InitializerOrFinalizer:
             return
         try:
             __import__(self.module_part)
-            loaded_function = getattr(
-                modules[self.module_part], self.function_part, None
-            )
+            loaded_function = getattr(modules[self.module_part], self.function_part, None)
         except Exception as e:
             raise InitializerOrFinalizerError(
                 "Couldn't load '{}' - got: {}".format(self.function_part, str(e))

--- a/green/suite.py
+++ b/green/suite.py
@@ -152,7 +152,9 @@ class GreenTestSuite(TestSuite):
                     raise
                 currentClass._classSetupFailed = True
                 className = util.strclass(currentClass)
-                self._createClassOrModuleLevelException(result, e, "setUpClass", className)
+                self._createClassOrModuleLevelException(
+                    result, e, "setUpClass", className
+                )
             finally:
                 _call_if_exists(result, "_restoreStdout")
                 if currentClass._classSetupFailed is True:

--- a/green/suite.py
+++ b/green/suite.py
@@ -152,9 +152,7 @@ class GreenTestSuite(TestSuite):
                     raise
                 currentClass._classSetupFailed = True
                 className = util.strclass(currentClass)
-                self._createClassOrModuleLevelException(
-                    result, e, "setUpClass", className
-                )
+                self._createClassOrModuleLevelException(result, e, "setUpClass", className)
             finally:
                 _call_if_exists(result, "_restoreStdout")
                 if currentClass._classSetupFailed is True:
@@ -240,7 +238,7 @@ class GreenTestSuite(TestSuite):
                 result.errors[:-difference],
                 result.errors[-difference:],
             )
-            for (test, err) in new_errors:
+            for test, err in new_errors:
                 # test = ProtoTest()
                 test.module = result._previousTestClass.__module__
                 test.class_name = result._previousTestClass.__name__

--- a/green/suite.py
+++ b/green/suite.py
@@ -1,6 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-
 from fnmatch import fnmatch
 import sys
 from unittest.suite import _call_if_exists, _DebugResult, _isnotsuite, TestSuite

--- a/green/test/test_cmdline.py
+++ b/green/test/test_cmdline.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from io import StringIO
 import logging
 import os
@@ -7,15 +6,11 @@ import shutil
 import sys
 import tempfile
 import unittest
+from unittest.mock import MagicMock
 
 from green import cmdline
 from green import config
 from green.output import GreenStream
-
-try:
-    from unittest.mock import MagicMock
-except:
-    from mock import MagicMock
 
 
 class TestMain(unittest.TestCase):

--- a/green/test/test_command.py
+++ b/green/test/test_command.py
@@ -17,7 +17,6 @@ from green.config import StoreOpt
 class TestCommand(unittest.TestCase):
     @contextlib.contextmanager
     def environ(self, setup_cfg=None, *args, **variables):
-
         args = ["green"] + list(args)
 
         if setup_cfg is not None:
@@ -28,9 +27,7 @@ class TestCommand(unittest.TestCase):
             with open("setup.cfg", "w") as f:
                 parser.write(f)
 
-        yield Distribution(
-            {"script_name": "setup.py", "script_args": args or ["green"]}
-        )
+        yield Distribution({"script_name": "setup.py", "script_args": args or ["green"]})
 
         # finally:
         if os.path.isfile("setup.cfg"):
@@ -69,9 +66,7 @@ class TestCommand(unittest.TestCase):
         argparser = argparse.ArgumentParser()
         store_opt(argparser.add_argument("-s", "--something", help="Something"))
         store_opt(argparser.add_argument("--else", help="Else"))
-        store_opt(
-            argparser.add_argument("-a", "--again", action="store_true", help="Again")
-        )
+        store_opt(argparser.add_argument("-a", "--again", action="store_true", help="Again"))
 
         args = argparser.parse_args([])
         args.parser = argparser

--- a/green/test/test_command.py
+++ b/green/test/test_command.py
@@ -1,19 +1,14 @@
-from __future__ import unicode_literals
-
 import argparse
 import contextlib
 import sys
 import unittest
+from unittest.mock import patch, MagicMock, call
 
 try:
     from setuptools.dist import Distribution
 except ImportError:
     from distutil.dist import Distribution
 
-try:
-    from mock import patch, MagicMock, call
-except:
-    from unittest.mock import patch, MagicMock, call
 
 from green import command
 from green.config import StoreOpt

--- a/green/test/test_command.py
+++ b/green/test/test_command.py
@@ -27,7 +27,9 @@ class TestCommand(unittest.TestCase):
             with open("setup.cfg", "w") as f:
                 parser.write(f)
 
-        yield Distribution({"script_name": "setup.py", "script_args": args or ["green"]})
+        yield Distribution(
+            {"script_name": "setup.py", "script_args": args or ["green"]}
+        )
 
         # finally:
         if os.path.isfile("setup.cfg"):
@@ -66,7 +68,9 @@ class TestCommand(unittest.TestCase):
         argparser = argparse.ArgumentParser()
         store_opt(argparser.add_argument("-s", "--something", help="Something"))
         store_opt(argparser.add_argument("--else", help="Else"))
-        store_opt(argparser.add_argument("-a", "--again", action="store_true", help="Again"))
+        store_opt(
+            argparser.add_argument("-a", "--again", action="store_true", help="Again")
+        )
 
         args = argparser.parse_args([])
         args.parser = argparser

--- a/green/test/test_config.py
+++ b/green/test/test_config.py
@@ -531,6 +531,4 @@ class TestMergeConfig(ConfigBase):
 
         new_args = copy.deepcopy(config.default_args)
 
-        self.assertRaises(
-            NotImplementedError, config.mergeConfig, new_args, testing=True
-        )
+        self.assertRaises(NotImplementedError, config.mergeConfig, new_args, testing=True)

--- a/green/test/test_config.py
+++ b/green/test/test_config.py
@@ -1,7 +1,4 @@
-try:
-    import configparser
-except:
-    import ConfigParser as configparser
+import configparser
 import copy
 from io import StringIO
 import os

--- a/green/test/test_config.py
+++ b/green/test/test_config.py
@@ -531,4 +531,6 @@ class TestMergeConfig(ConfigBase):
 
         new_args = copy.deepcopy(config.default_args)
 
-        self.assertRaises(NotImplementedError, config.mergeConfig, new_args, testing=True)
+        self.assertRaises(
+            NotImplementedError, config.mergeConfig, new_args, testing=True
+        )

--- a/green/test/test_djangorunner.py
+++ b/green/test/test_djangorunner.py
@@ -1,14 +1,9 @@
-from __future__ import unicode_literals
 from argparse import Namespace
 from argparse import ArgumentParser
 from io import StringIO
 import sys
 import unittest
-
-try:
-    from unittest.mock import MagicMock, patch
-except:
-    from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from green import djangorunner
 from green.config import mergeConfig

--- a/green/test/test_integration.py
+++ b/green/test/test_integration.py
@@ -7,11 +7,7 @@ import sys
 import tempfile
 from textwrap import dedent
 import unittest
-
-try:
-    from unittest.mock import MagicMock
-except:
-    from mock import MagicMock
+from unittest.mock import MagicMock
 
 from green import cmdline
 

--- a/green/test/test_junit.py
+++ b/green/test/test_junit.py
@@ -48,7 +48,9 @@ class JUnitXMLReportIsGenerated(TestCase):
         self._record_failure(test("my.module", "MyClass", "test_method3"))
         self._record_failure(test("my.module", "MyClass", "test_method4"))
         self._record_error(test("my.module", "MyClass", "test_method5"))
-        self._test_results.addSkip(test("my.module", "MyClass", "test_method6"), "Take too long")
+        self._test_results.addSkip(
+            test("my.module", "MyClass", "test_method6"), "Take too long"
+        )
 
         self._adapter.save_as(self._test_results, self._destination)
 
@@ -95,7 +97,9 @@ class JUnitXMLReportIsGenerated(TestCase):
         self._assert_report_is(
             {
                 "my_module.MyClass": {
-                    "tests": {"my_method": {"verdict": Verdict.PASSED, "stdout": output}}
+                    "tests": {
+                        "my_method": {"verdict": Verdict.PASSED, "stdout": output}
+                    }
                 }
             }
         )
@@ -110,7 +114,9 @@ class JUnitXMLReportIsGenerated(TestCase):
         self._assert_report_is(
             {
                 "my_module.MyClass": {
-                    "tests": {"my_method": {"verdict": Verdict.PASSED, "stderr": errput}}
+                    "tests": {
+                        "my_method": {"verdict": Verdict.PASSED, "stderr": errput}
+                    }
                 }
             }
         )
@@ -139,7 +145,11 @@ class JUnitXMLReportIsGenerated(TestCase):
         self._adapter.save_as(self._test_results, self._destination)
 
         self._assert_report_is(
-            {"my_module.MyClass": {"tests": {"my_method": {"verdict": Verdict.SKIPPED}}}}
+            {
+                "my_module.MyClass": {
+                    "tests": {"my_method": {"verdict": Verdict.SKIPPED}}
+                }
+            }
         )
 
     def test_convert_test_will_record_time_for_test(self):
@@ -186,19 +196,27 @@ class JUnitXMLReportIsGenerated(TestCase):
 
         # Check the count of tests
         if "#tests" in expected_suite:
-            self.assertEqual(expected_suite["#tests"], suite.get(JUnitDialect.TEST_COUNT))
+            self.assertEqual(
+                expected_suite["#tests"], suite.get(JUnitDialect.TEST_COUNT)
+            )
 
         # Check the count of failures
         if "#failures" in expected_suite:
-            self.assertEqual(expected_suite["#failures"], suite.get(JUnitDialect.FAILURE_COUNT))
+            self.assertEqual(
+                expected_suite["#failures"], suite.get(JUnitDialect.FAILURE_COUNT)
+            )
 
         # Check the count of errors
         if "#errors" in expected_suite:
-            self.assertEqual(expected_suite["#errors"], suite.get(JUnitDialect.ERROR_COUNT))
+            self.assertEqual(
+                expected_suite["#errors"], suite.get(JUnitDialect.ERROR_COUNT)
+            )
 
         # Check the count of skipped tests
         if "#skipped" in expected_suite:
-            self.assertEqual(expected_suite["#skipped"], suite.get(JUnitDialect.SKIPPED_COUNT))
+            self.assertEqual(
+                expected_suite["#skipped"], suite.get(JUnitDialect.SKIPPED_COUNT)
+            )
 
         # Check the time of each test
         if "time" in expected_suite:
@@ -206,7 +224,9 @@ class JUnitXMLReportIsGenerated(TestCase):
 
         # Check the time of total test run
         if "totaltesttime" in expected_suite:
-            self.assertEqual(expected_suite["totaltesttime"], suite.get(JUnitDialect.TEST_TIME))
+            self.assertEqual(
+                expected_suite["totaltesttime"], suite.get(JUnitDialect.TEST_TIME)
+            )
 
         # Check individual test reports
         self.assertEqual(len(expected_suite["tests"]), len(suite))

--- a/green/test/test_junit.py
+++ b/green/test/test_junit.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from green.config import default_args
 from green.output import GreenStream
 from green.junit import JUnitXML, JUnitDialect, Verdict

--- a/green/test/test_junit.py
+++ b/green/test/test_junit.py
@@ -48,9 +48,7 @@ class JUnitXMLReportIsGenerated(TestCase):
         self._record_failure(test("my.module", "MyClass", "test_method3"))
         self._record_failure(test("my.module", "MyClass", "test_method4"))
         self._record_error(test("my.module", "MyClass", "test_method5"))
-        self._test_results.addSkip(
-            test("my.module", "MyClass", "test_method6"), "Take too long"
-        )
+        self._test_results.addSkip(test("my.module", "MyClass", "test_method6"), "Take too long")
 
         self._adapter.save_as(self._test_results, self._destination)
 
@@ -97,9 +95,7 @@ class JUnitXMLReportIsGenerated(TestCase):
         self._assert_report_is(
             {
                 "my_module.MyClass": {
-                    "tests": {
-                        "my_method": {"verdict": Verdict.PASSED, "stdout": output}
-                    }
+                    "tests": {"my_method": {"verdict": Verdict.PASSED, "stdout": output}}
                 }
             }
         )
@@ -114,9 +110,7 @@ class JUnitXMLReportIsGenerated(TestCase):
         self._assert_report_is(
             {
                 "my_module.MyClass": {
-                    "tests": {
-                        "my_method": {"verdict": Verdict.PASSED, "stderr": errput}
-                    }
+                    "tests": {"my_method": {"verdict": Verdict.PASSED, "stderr": errput}}
                 }
             }
         )
@@ -145,11 +139,7 @@ class JUnitXMLReportIsGenerated(TestCase):
         self._adapter.save_as(self._test_results, self._destination)
 
         self._assert_report_is(
-            {
-                "my_module.MyClass": {
-                    "tests": {"my_method": {"verdict": Verdict.SKIPPED}}
-                }
-            }
+            {"my_module.MyClass": {"tests": {"my_method": {"verdict": Verdict.SKIPPED}}}}
         )
 
     def test_convert_test_will_record_time_for_test(self):
@@ -196,27 +186,19 @@ class JUnitXMLReportIsGenerated(TestCase):
 
         # Check the count of tests
         if "#tests" in expected_suite:
-            self.assertEqual(
-                expected_suite["#tests"], suite.get(JUnitDialect.TEST_COUNT)
-            )
+            self.assertEqual(expected_suite["#tests"], suite.get(JUnitDialect.TEST_COUNT))
 
         # Check the count of failures
         if "#failures" in expected_suite:
-            self.assertEqual(
-                expected_suite["#failures"], suite.get(JUnitDialect.FAILURE_COUNT)
-            )
+            self.assertEqual(expected_suite["#failures"], suite.get(JUnitDialect.FAILURE_COUNT))
 
         # Check the count of errors
         if "#errors" in expected_suite:
-            self.assertEqual(
-                expected_suite["#errors"], suite.get(JUnitDialect.ERROR_COUNT)
-            )
+            self.assertEqual(expected_suite["#errors"], suite.get(JUnitDialect.ERROR_COUNT))
 
         # Check the count of skipped tests
         if "#skipped" in expected_suite:
-            self.assertEqual(
-                expected_suite["#skipped"], suite.get(JUnitDialect.SKIPPED_COUNT)
-            )
+            self.assertEqual(expected_suite["#skipped"], suite.get(JUnitDialect.SKIPPED_COUNT))
 
         # Check the time of each test
         if "time" in expected_suite:
@@ -224,9 +206,7 @@ class JUnitXMLReportIsGenerated(TestCase):
 
         # Check the time of total test run
         if "totaltesttime" in expected_suite:
-            self.assertEqual(
-                expected_suite["totaltesttime"], suite.get(JUnitDialect.TEST_TIME)
-            )
+            self.assertEqual(expected_suite["totaltesttime"], suite.get(JUnitDialect.TEST_TIME))
 
         # Check individual test reports
         self.assertEqual(len(expected_suite["tests"]), len(suite))

--- a/green/test/test_load_tests.py
+++ b/green/test/test_load_tests.py
@@ -1,15 +1,9 @@
-from __future__ import unicode_literals
-
 import os
+from queue import Queue, Empty
 import shutil
 import tempfile
 import unittest
 import textwrap
-
-try:
-    from Queue import Queue, Empty
-except ImportError:
-    from queue import Queue, Empty
 
 from green.loader import GreenTestLoader
 from green.process import poolRunner

--- a/green/test/test_load_tests.py
+++ b/green/test/test_load_tests.py
@@ -40,7 +40,9 @@ class TestLoadTests(unittest.TestCase):
         actually changes the referenced class.
         """
 
-        with open(os.path.join(self.basename, "test_load_tests_monkeypatch.py"), "w") as f:
+        with open(
+            os.path.join(self.basename, "test_load_tests_monkeypatch.py"), "w"
+        ) as f:
             f.write(
                 textwrap.dedent(
                     """
@@ -74,7 +76,9 @@ class TestLoadTests(unittest.TestCase):
         another TestSuite (or maybe not even a unittest.TestSuite).
         """
 
-        with open(os.path.join(self.basename, "test_load_keys_foreign_suite.py"), "w") as f:
+        with open(
+            os.path.join(self.basename, "test_load_keys_foreign_suite.py"), "w"
+        ) as f:
             f.write(
                 textwrap.dedent(
                     """
@@ -109,7 +113,9 @@ class TestLoadTests(unittest.TestCase):
         """
         Check that if load_tests returns None, no tests are run.
         """
-        with open(os.path.join(self.basename, "test_load_keys_none_cancels.py"), "w") as fh:
+        with open(
+            os.path.join(self.basename, "test_load_keys_none_cancels.py"), "w"
+        ) as fh:
             fh.write(
                 textwrap.dedent(
                     """

--- a/green/test/test_load_tests.py
+++ b/green/test/test_load_tests.py
@@ -40,9 +40,7 @@ class TestLoadTests(unittest.TestCase):
         actually changes the referenced class.
         """
 
-        with open(
-            os.path.join(self.basename, "test_load_tests_monkeypatch.py"), "w"
-        ) as f:
+        with open(os.path.join(self.basename, "test_load_tests_monkeypatch.py"), "w") as f:
             f.write(
                 textwrap.dedent(
                     """
@@ -76,9 +74,7 @@ class TestLoadTests(unittest.TestCase):
         another TestSuite (or maybe not even a unittest.TestSuite).
         """
 
-        with open(
-            os.path.join(self.basename, "test_load_keys_foreign_suite.py"), "w"
-        ) as f:
+        with open(os.path.join(self.basename, "test_load_keys_foreign_suite.py"), "w") as f:
             f.write(
                 textwrap.dedent(
                     """
@@ -113,9 +109,7 @@ class TestLoadTests(unittest.TestCase):
         """
         Check that if load_tests returns None, no tests are run.
         """
-        with open(
-            os.path.join(self.basename, "test_load_keys_none_cancels.py"), "w"
-        ) as fh:
+        with open(os.path.join(self.basename, "test_load_keys_none_cancels.py"), "w") as fh:
             fh.write(
                 textwrap.dedent(
                     """

--- a/green/test/test_loader.py
+++ b/green/test/test_loader.py
@@ -138,7 +138,9 @@ class TestCompletions(unittest.TestCase):
         self.assertIn("green.test", c)
         self.assertIn("green.test.test_loader", c)
         self.assertIn("green.test.test_loader.TestCompletions", c)
-        self.assertIn("green.test.test_loader.TestCompletions.test_completionPartialShort", c)
+        self.assertIn(
+            "green.test.test_loader.TestCompletions.test_completionPartialShort", c
+        )
 
     def test_completionPartial(self):
         """
@@ -148,7 +150,9 @@ class TestCompletions(unittest.TestCase):
         self.assertIn("green.test", c)
         self.assertIn("green.test.test_loader", c)
         self.assertIn("green.test.test_loader.TestCompletions", c)
-        self.assertIn("green.test.test_loader.TestCompletions.test_completionPartial", c)
+        self.assertIn(
+            "green.test.test_loader.TestCompletions.test_completionPartial", c
+        )
         self.assertNotIn("green", c)
 
     def test_completionEmpty(self):
@@ -288,7 +292,9 @@ class TestDottedModule(unittest.TestCase):
         """
         A bad path causes an exception
         """
-        self.assertRaises(ValueError, loader.findDottedModuleAndParentDir, tempfile.tempdir)
+        self.assertRaises(
+            ValueError, loader.findDottedModuleAndParentDir, tempfile.tempdir
+        )
 
     def test_good_path(self):
         """
@@ -426,7 +432,9 @@ class TestDiscover(unittest.TestCase):
         """
         tmpdir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, tmpdir)
-        self.assertRaises(ImportError, self.loader.discover, os.path.join(tmpdir, "garbage_in"))
+        self.assertRaises(
+            ImportError, self.loader.discover, os.path.join(tmpdir, "garbage_in")
+        )
         filename = os.path.join(tmpdir, "some_file.py")
         fh = open(filename, "w")
         fh.write("pass\n")
@@ -756,7 +764,9 @@ class TestLoadTargets(unittest.TestCase):
         fh = open(os.path.join(self.tmpdir, "__init__.py"), "w")
         fh.write("\n")
         fh.close()
-        malformed_module = os.path.join(os.path.basename(self.tmpdir), "malformed_module.py")
+        malformed_module = os.path.join(
+            os.path.basename(self.tmpdir), "malformed_module.py"
+        )
         fh = open(malformed_module, "w")
         fh.write("This is a malformed module.")
         fh.close()
@@ -834,7 +844,9 @@ class TestLoadTargets(unittest.TestCase):
         # Load the tests
         os.chdir(self.tmpdir)
         pkg = os.path.basename(sub_tmpdir)
-        tests = self.loader.loadTargets([pkg + "." + "test_target1", pkg + "." + "test_target2"])
+        tests = self.loader.loadTargets(
+            [pkg + "." + "test_target1", pkg + "." + "test_target2"]
+        )
         self.assertEqual(tests.countTestCases(), 2)
 
     def test_duplicate_targets(self):
@@ -916,7 +928,9 @@ class TestLoadTargets(unittest.TestCase):
             self.assertIn("mod_with_syntax_error.TestSyntax.test_syntax", str(e))
             hit_exception = True
         if not hit_exception:
-            self.fail("An exception should have been raised about the syntax error. :-(")
+            self.fail(
+                "An exception should have been raised about the syntax error. :-("
+            )
 
     def test_file_pattern(self):
         """

--- a/green/test/test_loader.py
+++ b/green/test/test_loader.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 import os
 from os.path import dirname
 import platform
@@ -7,11 +6,7 @@ import sys
 import tempfile
 from textwrap import dedent
 import unittest
-
-try:
-    from unittest.mock import MagicMock, patch
-except:
-    from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from green import loader
 from green.loader import GreenTestLoader, flattenTestSuite

--- a/green/test/test_loader.py
+++ b/green/test/test_loader.py
@@ -138,9 +138,7 @@ class TestCompletions(unittest.TestCase):
         self.assertIn("green.test", c)
         self.assertIn("green.test.test_loader", c)
         self.assertIn("green.test.test_loader.TestCompletions", c)
-        self.assertIn(
-            "green.test.test_loader.TestCompletions.test_completionPartialShort", c
-        )
+        self.assertIn("green.test.test_loader.TestCompletions.test_completionPartialShort", c)
 
     def test_completionPartial(self):
         """
@@ -150,9 +148,7 @@ class TestCompletions(unittest.TestCase):
         self.assertIn("green.test", c)
         self.assertIn("green.test.test_loader", c)
         self.assertIn("green.test.test_loader.TestCompletions", c)
-        self.assertIn(
-            "green.test.test_loader.TestCompletions.test_completionPartial", c
-        )
+        self.assertIn("green.test.test_loader.TestCompletions.test_completionPartial", c)
         self.assertNotIn("green", c)
 
     def test_completionEmpty(self):
@@ -292,9 +288,7 @@ class TestDottedModule(unittest.TestCase):
         """
         A bad path causes an exception
         """
-        self.assertRaises(
-            ValueError, loader.findDottedModuleAndParentDir, tempfile.tempdir
-        )
+        self.assertRaises(ValueError, loader.findDottedModuleAndParentDir, tempfile.tempdir)
 
     def test_good_path(self):
         """
@@ -432,9 +426,7 @@ class TestDiscover(unittest.TestCase):
         """
         tmpdir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, tmpdir)
-        self.assertRaises(
-            ImportError, self.loader.discover, os.path.join(tmpdir, "garbage_in")
-        )
+        self.assertRaises(ImportError, self.loader.discover, os.path.join(tmpdir, "garbage_in"))
         filename = os.path.join(tmpdir, "some_file.py")
         fh = open(filename, "w")
         fh.write("pass\n")
@@ -508,7 +500,6 @@ class TestDiscover(unittest.TestCase):
 
 
 class TestLoadTargets(unittest.TestCase):
-
     # Setup
     @classmethod
     def setUpClass(cls):
@@ -765,9 +756,7 @@ class TestLoadTargets(unittest.TestCase):
         fh = open(os.path.join(self.tmpdir, "__init__.py"), "w")
         fh.write("\n")
         fh.close()
-        malformed_module = os.path.join(
-            os.path.basename(self.tmpdir), "malformed_module.py"
-        )
+        malformed_module = os.path.join(os.path.basename(self.tmpdir), "malformed_module.py")
         fh = open(malformed_module, "w")
         fh.write("This is a malformed module.")
         fh.close()
@@ -845,9 +834,7 @@ class TestLoadTargets(unittest.TestCase):
         # Load the tests
         os.chdir(self.tmpdir)
         pkg = os.path.basename(sub_tmpdir)
-        tests = self.loader.loadTargets(
-            [pkg + "." + "test_target1", pkg + "." + "test_target2"]
-        )
+        tests = self.loader.loadTargets([pkg + "." + "test_target1", pkg + "." + "test_target2"])
         self.assertEqual(tests.countTestCases(), 2)
 
     def test_duplicate_targets(self):
@@ -929,9 +916,7 @@ class TestLoadTargets(unittest.TestCase):
             self.assertIn("mod_with_syntax_error.TestSyntax.test_syntax", str(e))
             hit_exception = True
         if not hit_exception:
-            self.fail(
-                "An exception should have been raised about the syntax error. :-("
-            )
+            self.fail("An exception should have been raised about the syntax error. :-(")
 
     def test_file_pattern(self):
         """
@@ -989,7 +974,6 @@ class TestLoadTargets(unittest.TestCase):
 
 
 class TestFlattenTestSuite(unittest.TestCase):
-
     # Setup
     @classmethod
     def setUpClass(cls):

--- a/green/test/test_output.py
+++ b/green/test/test_output.py
@@ -1,14 +1,8 @@
-from __future__ import unicode_literals
 from io import StringIO
 import platform
 import sys
 import unittest
-
-
-try:
-    from unittest.mock import MagicMock, patch
-except:
-    from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from green.output import Colors, GreenStream, debug
 import green.output

--- a/green/test/test_process.py
+++ b/green/test/test_process.py
@@ -1,23 +1,16 @@
 from ctypes import c_double
 import os
 import multiprocessing
+from queue import Queue, Empty
 import shutil
 import tempfile
 from textwrap import dedent
 import unittest
-
-try:
-    from unittest.mock import MagicMock
-except:
-    from mock import MagicMock
+from unittest.mock import MagicMock
 
 from green.process import ProcessLogger, poolRunner
 from green import process
 
-try:
-    from Queue import Queue, Empty
-except:
-    from queue import Queue, Empty
 
 
 class TestProcessLogger(unittest.TestCase):

--- a/green/test/test_process.py
+++ b/green/test/test_process.py
@@ -40,7 +40,9 @@ class TestProcessLogger(unittest.TestCase):
         mock_get_logger = MagicMock()
         mock_get_logger.return_value = mock_logger
         process.multiprocessing.get_logger = mock_get_logger
-        self.addCleanup(setattr, process.multiprocessing, "get_logger", saved_get_logger)
+        self.addCleanup(
+            setattr, process.multiprocessing, "get_logger", saved_get_logger
+        )
 
         def func():
             raise AttributeError

--- a/green/test/test_process.py
+++ b/green/test/test_process.py
@@ -12,7 +12,6 @@ from green.process import ProcessLogger, poolRunner
 from green import process
 
 
-
 class TestProcessLogger(unittest.TestCase):
     def test_callThrough(self):
         """
@@ -41,9 +40,7 @@ class TestProcessLogger(unittest.TestCase):
         mock_get_logger = MagicMock()
         mock_get_logger.return_value = mock_logger
         process.multiprocessing.get_logger = mock_get_logger
-        self.addCleanup(
-            setattr, process.multiprocessing, "get_logger", saved_get_logger
-        )
+        self.addCleanup(setattr, process.multiprocessing, "get_logger", saved_get_logger)
 
         def func():
             raise AttributeError
@@ -54,7 +51,6 @@ class TestProcessLogger(unittest.TestCase):
 
 
 class TestPoolRunner(unittest.TestCase):
-
     # Setup
     @classmethod
     def setUpClass(cls):

--- a/green/test/test_result.py
+++ b/green/test/test_result.py
@@ -379,13 +379,17 @@ class TestGreenTestResult(unittest.TestCase):
         We ignore coverage's error about not having anything to cover.
         """
         self.args.cov = MagicMock()
-        self.args.cov.stop = MagicMock(side_effect=CoverageException("Different Exception"))
+        self.args.cov.stop = MagicMock(
+            side_effect=CoverageException("Different Exception")
+        )
         self.args.run_coverage = True
         gtr = GreenTestResult(self.args, GreenStream(self.stream))
         gtr.startTestRun()
         self.assertRaises(CoverageException, gtr.stopTestRun)
 
-        self.args.cov.stop = MagicMock(side_effect=CoverageException("No data to report"))
+        self.args.cov.stop = MagicMock(
+            side_effect=CoverageException("No data to report")
+        )
 
     def test_tryRecordingStdoutStderr(self):
         """
@@ -875,7 +879,9 @@ class TestGreenTestResultAdds(unittest.TestCase):
         test = proto_test(MagicMock())
         err = proto_error(err)
         self.gtr.addError(test, err)
-        self.gtr._reportOutcome.assert_called_with(test, "E", self.gtr.colors.error, err)
+        self.gtr._reportOutcome.assert_called_with(
+            test, "E", self.gtr.colors.error, err
+        )
 
     def test_addError_with_test_time(self):
         """
@@ -903,7 +909,9 @@ class TestGreenTestResultAdds(unittest.TestCase):
         test = proto_test(MagicMock())
         err = proto_error(err)
         self.gtr.addFailure(test, err)
-        self.gtr._reportOutcome.assert_called_with(test, "F", self.gtr.colors.failing, err)
+        self.gtr._reportOutcome.assert_called_with(
+            test, "F", self.gtr.colors.failing, err
+        )
 
     def test_addFailure_with_test_time(self):
         """
@@ -971,7 +979,9 @@ class TestGreenTestResultAdds(unittest.TestCase):
         test = proto_test(MagicMock())
         err = proto_error(err)
         self.gtr.addExpectedFailure(test, err)
-        self.gtr._reportOutcome.assert_called_with(test, "x", self.gtr.colors.expectedFailure, err)
+        self.gtr._reportOutcome.assert_called_with(
+            test, "x", self.gtr.colors.expectedFailure, err
+        )
 
     def test_addExcepectedFailure_with_test_time(self):
         """
@@ -993,7 +1003,9 @@ class TestGreenTestResultAdds(unittest.TestCase):
         """
         test = proto_test(MagicMock())
         self.gtr.addUnexpectedSuccess(test)
-        self.gtr._reportOutcome.assert_called_with(test, "u", self.gtr.colors.unexpectedSuccess)
+        self.gtr._reportOutcome.assert_called_with(
+            test, "u", self.gtr.colors.unexpectedSuccess
+        )
 
     def test_addUnexpectedSuccess_with_test_time(self):
         """

--- a/green/test/test_result.py
+++ b/green/test/test_result.py
@@ -259,6 +259,7 @@ class TestProtoTest(unittest.TestCase):
         """
         getDescription() returns what we expect for all verbose levels
         """
+
         # With a docstring
         class Fruit(unittest.TestCase):
             def test_stuff(self):
@@ -378,17 +379,13 @@ class TestGreenTestResult(unittest.TestCase):
         We ignore coverage's error about not having anything to cover.
         """
         self.args.cov = MagicMock()
-        self.args.cov.stop = MagicMock(
-            side_effect=CoverageException("Different Exception")
-        )
+        self.args.cov.stop = MagicMock(side_effect=CoverageException("Different Exception"))
         self.args.run_coverage = True
         gtr = GreenTestResult(self.args, GreenStream(self.stream))
         gtr.startTestRun()
         self.assertRaises(CoverageException, gtr.stopTestRun)
 
-        self.args.cov.stop = MagicMock(
-            side_effect=CoverageException("No data to report")
-        )
+        self.args.cov.stop = MagicMock(side_effect=CoverageException("No data to report"))
 
     def test_tryRecordingStdoutStderr(self):
         """
@@ -878,9 +875,7 @@ class TestGreenTestResultAdds(unittest.TestCase):
         test = proto_test(MagicMock())
         err = proto_error(err)
         self.gtr.addError(test, err)
-        self.gtr._reportOutcome.assert_called_with(
-            test, "E", self.gtr.colors.error, err
-        )
+        self.gtr._reportOutcome.assert_called_with(test, "E", self.gtr.colors.error, err)
 
     def test_addError_with_test_time(self):
         """
@@ -908,9 +903,7 @@ class TestGreenTestResultAdds(unittest.TestCase):
         test = proto_test(MagicMock())
         err = proto_error(err)
         self.gtr.addFailure(test, err)
-        self.gtr._reportOutcome.assert_called_with(
-            test, "F", self.gtr.colors.failing, err
-        )
+        self.gtr._reportOutcome.assert_called_with(test, "F", self.gtr.colors.failing, err)
 
     def test_addFailure_with_test_time(self):
         """
@@ -978,9 +971,7 @@ class TestGreenTestResultAdds(unittest.TestCase):
         test = proto_test(MagicMock())
         err = proto_error(err)
         self.gtr.addExpectedFailure(test, err)
-        self.gtr._reportOutcome.assert_called_with(
-            test, "x", self.gtr.colors.expectedFailure, err
-        )
+        self.gtr._reportOutcome.assert_called_with(test, "x", self.gtr.colors.expectedFailure, err)
 
     def test_addExcepectedFailure_with_test_time(self):
         """
@@ -1002,9 +993,7 @@ class TestGreenTestResultAdds(unittest.TestCase):
         """
         test = proto_test(MagicMock())
         self.gtr.addUnexpectedSuccess(test)
-        self.gtr._reportOutcome.assert_called_with(
-            test, "u", self.gtr.colors.unexpectedSuccess
-        )
+        self.gtr._reportOutcome.assert_called_with(test, "u", self.gtr.colors.unexpectedSuccess)
 
     def test_addUnexpectedSuccess_with_test_time(self):
         """

--- a/green/test/test_result.py
+++ b/green/test/test_result.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import copy
 
 # `from doctest import DocTestCase` causes crashes, since the DocTestCase is
@@ -11,6 +10,7 @@ from io import StringIO
 import sys
 import os
 import unittest
+from unittest.mock import MagicMock, patch
 import tempfile
 
 from green.config import default_args
@@ -23,11 +23,6 @@ from green.result import (
     ProtoTestResult,
     BaseTestResult,
 )
-
-try:
-    from unittest.mock import MagicMock, patch
-except ImportError:
-    from mock import MagicMock, patch
 
 from coverage import coverage, CoverageException
 

--- a/green/test/test_runner.py
+++ b/green/test/test_runner.py
@@ -283,7 +283,6 @@ class TestRun(unittest.TestCase):
 
 
 class TestProcesses(unittest.TestCase):
-
     # Setup
     @classmethod
     def setUpClass(cls):

--- a/green/test/test_runner.py
+++ b/green/test/test_runner.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 import copy
 from io import StringIO
 import os
@@ -9,6 +8,7 @@ import sys
 import tempfile
 from textwrap import dedent
 import unittest
+from unittest.mock import MagicMock
 import weakref
 
 from green.config import default_args
@@ -17,11 +17,6 @@ from green.loader import GreenTestLoader
 from green.output import GreenStream
 from green.runner import InitializerOrFinalizer, run
 from green.suite import GreenTestSuite
-
-try:
-    from unittest.mock import MagicMock
-except:
-    from mock import MagicMock
 
 
 global skip_testtools

--- a/green/test/test_suite.py
+++ b/green/test/test_suite.py
@@ -1,18 +1,10 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-
 import copy
 from io import StringIO
 import os
 import tempfile
 from textwrap import dedent
 import unittest
-
-
-try:
-    from unittest.mock import MagicMock
-except:
-    from mock import MagicMock
+from unittest.mock import MagicMock
 
 from green.config import default_args
 from green.loader import GreenTestLoader

--- a/green/test/test_version.py
+++ b/green/test/test_version.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 import unittest
 
 from green.version import __version__, pretty_version

--- a/green/version.py
+++ b/green/version.py
@@ -1,17 +1,10 @@
-from __future__ import unicode_literals  # pragma: no cover
-import os.path  # pragma nocover
+import pathlib  # pragma nocover
 import sys  # pragma nocover
 
 import coverage  # pragma: no cover
 
-with open(
-    os.path.join(os.path.dirname(__file__), "VERSION")
-) as vfile:  # pragma nocover
-    __version__ = vfile.read().strip()
-if sys.version_info[0] == 2:  # pragma nocover
-    from __builtin__ import unicode  # just so the linter stops complaining
 
-    __version__ = unicode(__version__)
+__version__ = (pathlib.Path(__file__).parent / "VERSION").read_text(encoding='utf-8').strip()
 
 
 def pretty_version():  # pragma nocover

--- a/green/version.py
+++ b/green/version.py
@@ -4,7 +4,9 @@ import sys  # pragma nocover
 import coverage  # pragma: no cover
 
 
-__version__ = (pathlib.Path(__file__).parent / "VERSION").read_text(encoding='utf-8').strip()
+__version__ = (
+    (pathlib.Path(__file__).parent / "VERSION").read_text(encoding="utf-8").strip()
+)
 
 
 def pretty_version():  # pragma nocover


### PR DESCRIPTION
Tested with `green green` with python 3.6 (some of the test code uses f-strings so we cannot test with python 3.5).