### PR TITLE
Address 'addDuration' warnings in python 3.12.

### DIFF
--- a/green/config.py
+++ b/green/config.py
@@ -634,17 +634,14 @@ def getConfig(filepath=None):  # pragma: no cover
     if filepaths:
         global files_loaded
         files_loaded = filepaths
-        # Python 3 has parser.read_file(iterator) while Python2 has
-        # parser.readfp(obj_with_readline)
-        read_func = getattr(parser, "read_file", getattr(parser, "readfp"))
         for filepath in filepaths:
             # Users are expected to put a [green] section
             # only if they use setup.cfg
             if filepath.endswith("setup.cfg"):
                 with open(filepath) as f:
-                    read_func(f)
+                    parser.read_file(f)
             else:
-                read_func(ConfigFile(filepath))
+                parser.read_file(ConfigFile(filepath))
 
     return parser
 

--- a/green/result.py
+++ b/green/result.py
@@ -165,6 +165,8 @@ class BaseTestResult:
         self.stderr_errput = OrderedDict()
         self.stream = stream
         self.colors = colors
+        # The collectedDurations list is new in Python 3.12.
+        self.collectedDurations = []
 
     def recordStdout(self, test, output):
         """
@@ -218,6 +220,19 @@ class BaseTestResult:
             )
             del self.stderr_errput[test]
 
+    def addDuration(self, test, elapsed):
+        """
+        Called when a test finished running, regardless of its outcome.
+
+        New in Python 3.12.
+
+        Args:
+            test: The test case corresponding to the test method.
+            elapsed: The time represented in seconds, including the
+                execution of cleanup functions.
+        """
+        self.collectedDurations.append((str(test), elapsed))
+
 
 class ProtoTestResult(BaseTestResult):
     """
@@ -247,6 +262,7 @@ class ProtoTestResult(BaseTestResult):
 
     def reinitialize(self):
         self.shouldStop = False
+        self.collectedDurations = []
         self.errors = []
         self.expectedFailures = []
         self.failures = []
@@ -392,6 +408,7 @@ class GreenTestResult(BaseTestResult):
         self.shouldStop = False
         self.testsRun = 0
         # Individual lists
+        self.collectedDurations = []
         self.errors = []
         self.expectedFailures = []
         self.failures = []


### PR DESCRIPTION
This is new to python 3.12 and throws warning on every single test. This adds the new method and related property. Longer term we should probably inherit from the official TestResult class as to ensure better forward compatibility.

This depends on #274.