### PR TITLE
Improve support for local testing.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Install
         run: |
           python -m pip install --upgrade pip
-          pip install --upgrade -r requirements-optional.txt
-          pip install --upgrade -e .
+          pip install --upgrade .[dev]
 
       - name: Format
         run: black --check --diff green example

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Unreleased
 #### Date TBD
 
+- Cleanup test_runner.py to more modern Python style.
+- Simplify green's dev testing setup.
+
 # Version 4.0.0
 #### 16 Jan 2024
 

--- a/green/test/test_runner.py
+++ b/green/test/test_runner.py
@@ -1,6 +1,7 @@
 import copy
 from io import StringIO
 import os
+import pathlib
 import platform
 import shutil
 import signal
@@ -8,7 +9,7 @@ import sys
 import tempfile
 from textwrap import dedent
 import unittest
-from unittest.mock import MagicMock
+from unittest import mock
 import weakref
 
 from green.config import default_args
@@ -19,7 +20,6 @@ from green.runner import InitializerOrFinalizer, run
 from green.suite import GreenTestSuite
 
 
-global skip_testtools
 skip_testtools = False
 try:
     import testtools
@@ -31,7 +31,6 @@ except:
 
 # --- Helper stuff ---
 
-global importable_function_worked
 importable_function_worked = False
 
 
@@ -50,7 +49,7 @@ def _crashy():
     """
     Used by TestInitializerOrFinalizer.test_crash()
     """
-    raise Exception("Oops!  I crashed.")
+    raise AssertionError("Oops!  I crashed.")
 
 
 # --- End of helper stuff
@@ -128,7 +127,7 @@ class TestRun(unittest.TestCase):
         run(GreenTestSuite(), sys.stdout, args=self.args)
         self.assertIn("No Tests Found", self.stream.getvalue())
 
-    def test_GreenStream(self):
+    def test_green_stream(self):
         """
         run() can use a GreenStream for output.
         """
@@ -141,23 +140,21 @@ class TestRun(unittest.TestCase):
         verbose=3 causes version output, and an empty test case passes.
         """
         self.args.verbose = 3
-        sub_tmpdir = tempfile.mkdtemp(dir=self.tmpdir)
-        fh = open(os.path.join(sub_tmpdir, "test_verbose3.py"), "w")
-        fh.write(
-            dedent(
-                """
+        sub_tmpdir = pathlib.Path(tempfile.mkdtemp(dir=self.tmpdir))
+        content = dedent("""
             import unittest
             class Verbose3(unittest.TestCase):
                 def test01(self):
                     pass
             """
-            )
         )
-        fh.close()
+        (sub_tmpdir / "test_verbose3.py").write_text(content, encoding="utf-8")
         os.chdir(sub_tmpdir)
-        tests = self.loader.loadTargets("test_verbose3")
-        result = run(tests, self.stream, self.args)
-        os.chdir(self.startdir)
+        try:
+            tests = self.loader.loadTargets("test_verbose3")
+            result = run(tests, self.stream, self.args)
+        finally:
+            os.chdir(self.startdir)
         self.assertEqual(result.testsRun, 1)
         self.assertIn("Green", self.stream.getvalue())
         self.assertIn("OK", self.stream.getvalue())
@@ -167,27 +164,26 @@ class TestRun(unittest.TestCase):
         setting warnings='always' doesn't crash
         """
         self.args.warnings = "always"
-        sub_tmpdir = tempfile.mkdtemp(dir=self.tmpdir)
-        fh = open(os.path.join(sub_tmpdir, "test_warnings.py"), "w")
-        fh.write(
-            dedent(
-                """
+        sub_tmpdir = pathlib.Path(tempfile.mkdtemp(dir=self.tmpdir))
+        content = dedent(
+            """
             import unittest
             class Warnings(unittest.TestCase):
                 def test01(self):
                     pass
             """
-            )
         )
-        fh.close()
+        (sub_tmpdir / "test_warnings.py").write_text(content, encoding="utf-8")
         os.chdir(sub_tmpdir)
-        tests = self.loader.loadTargets("test_warnings")
-        result = run(tests, self.stream, self.args)
-        os.chdir(self.startdir)
+        try:
+            tests = self.loader.loadTargets("test_warnings")
+            result = run(tests, self.stream, self.args)
+        finally:
+            os.chdir(self.startdir)
         self.assertEqual(result.testsRun, 1)
         self.assertIn("OK", self.stream.getvalue())
 
-    def test_noTestsFound(self):
+    def test_no_tests_found(self):
         """
         When we don't find any tests, we say so.
         """
@@ -196,27 +192,26 @@ class TestRun(unittest.TestCase):
         self.assertEqual(result.testsRun, 0)
         self.assertEqual(result.wasSuccessful(), False)
 
-    def test_failedSaysSo(self):
+    def test_failed_says_so(self):
         """
         A failing test case causes the whole run to report 'FAILED'
         """
-        sub_tmpdir = tempfile.mkdtemp(dir=self.tmpdir)
-        fh = open(os.path.join(sub_tmpdir, "test_failed.py"), "w")
-        fh.write(
-            dedent(
-                """
+        sub_tmpdir = pathlib.Path(tempfile.mkdtemp(dir=self.tmpdir))
+        content = dedent(
+            """
             import unittest
             class Failed(unittest.TestCase):
                 def test01(self):
                     self.assertTrue(False)
             """
-            )
         )
-        fh.close()
+        (sub_tmpdir / "test_failed.py").write_text(content, encoding="utf-8")
         os.chdir(sub_tmpdir)
-        tests = self.loader.loadTargets("test_failed")
-        result = run(tests, self.stream, self.args)
-        os.chdir(self.startdir)
+        try:
+            tests = self.loader.loadTargets("test_failed")
+            result = run(tests, self.stream, self.args)
+        finally:
+            os.chdir(self.startdir)
         self.assertEqual(result.testsRun, 1)
         self.assertIn("FAILED", self.stream.getvalue())
 
@@ -224,11 +219,9 @@ class TestRun(unittest.TestCase):
         """
         failfast causes the testing to stop after the first failure.
         """
-        sub_tmpdir = tempfile.mkdtemp(dir=self.tmpdir)
-        fh = open(os.path.join(sub_tmpdir, "test_failfast.py"), "w")
-        fh.write(
-            dedent(
-                """
+        sub_tmpdir = pathlib.Path(tempfile.mkdtemp(dir=self.tmpdir))
+        content = dedent(
+            """
             import unittest
             class SIGINTCase(unittest.TestCase):
                 def test00(self):
@@ -236,25 +229,24 @@ class TestRun(unittest.TestCase):
                 def test01(self):
                     pass
             """
-            )
         )
-        fh.close()
+        (sub_tmpdir / "test_failfast.py").write_text(content, encoding="utf-8")
         os.chdir(sub_tmpdir)
-        tests = self.loader.loadTargets("test_failfast")
-        self.args.failfast = True
-        result = run(tests, self.stream, self.args)
-        os.chdir(self.startdir)
+        try:
+            tests = self.loader.loadTargets("test_failfast")
+            self.args.failfast = True
+            result = run(tests, self.stream, self.args)
+        finally:
+            os.chdir(self.startdir)
         self.assertEqual(result.testsRun, 1)
 
-    def test_systemExit(self):
+    def test_system_exit(self):
         """
         Raising a SystemExit gets caught and reported.
         """
-        sub_tmpdir = tempfile.mkdtemp(dir=self.tmpdir)
-        fh = open(os.path.join(sub_tmpdir, "test_systemexit.py"), "w")
-        fh.write(
-            dedent(
-                """
+        sub_tmpdir = pathlib.Path(tempfile.mkdtemp(dir=self.tmpdir))
+        content = dedent(
+            """
             import unittest
             class SystemExitCase(unittest.TestCase):
                 def test00(self):
@@ -262,13 +254,14 @@ class TestRun(unittest.TestCase):
                 def test01(self):
                     pass
             """
-            )
         )
-        fh.close()
+        (sub_tmpdir / "test_systemexit.py").write_text(content, encoding="utf-8")
         os.chdir(sub_tmpdir)
-        tests = self.loader.loadTargets("test_systemexit")
-        result = run(tests, self.stream, self.args)
-        os.chdir(self.startdir)
+        try:
+            tests = self.loader.loadTargets("test_systemexit")
+            result = run(tests, self.stream, self.args)
+        finally:
+            os.chdir(self.startdir)
         self.assertEqual(result.testsRun, 2)
 
 
@@ -300,66 +293,54 @@ class TestProcesses(unittest.TestCase):
         shutil.rmtree(self.tmpdir, ignore_errors=True)
         del self.stream
 
-    def test_catchProcessSIGINT(self):
+    @unittest.skipIf(platform.system() == "Windows", "Windows doesn't have SIGINT.")
+    def test_catch_process_sigint(self):
         """
         run() can catch SIGINT while running a process.
         """
-        if platform.system() == "Windows":
-            self.skipTest("This test is for posix-specific behavior.")
         # Mock the list of TestResult instances that should be stopped,
         # otherwise the actual TestResult that is running this test will be
         # told to stop when we send SIGINT
-        sub_tmpdir = tempfile.mkdtemp(dir=self.tmpdir)
+        sub_tmpdir = pathlib.Path(tempfile.mkdtemp(dir=self.tmpdir))
         saved__results = unittest.signals._results
         unittest.signals._results = weakref.WeakKeyDictionary()
         self.addCleanup(setattr, unittest.signals, "_results", saved__results)
-        fh = open(os.path.join(sub_tmpdir, "test_sigint.py"), "w")
-        fh.write(
-            dedent(
-                """
+        content = dedent(
+            """
             import os
             import signal
             import unittest
-            class SIGINTCase(unittest.TestCase):
-                def test00(self):
+            class TestSigint(unittest.TestCase):
+                def test_00(self):
                     os.kill({}, signal.SIGINT)
-            """.format(
-                    os.getpid()
-                )
-            )
-        )
-        fh.close()
+            """
+        ).format(os.getpid())
+        (sub_tmpdir / "test_sigint.py").write_text(content, encoding="utf-8")
         os.chdir(sub_tmpdir)
-        tests = self.loader.loadTargets("test_sigint")
-        self.args.processes = 2
-        run(tests, self.stream, self.args)
-        os.chdir(TestProcesses.startdir)
+        try:
+            tests = self.loader.loadTargets("test_sigint")
+            self.args.processes = 2
+            run(tests, self.stream, self.args)
+        finally:
+            os.chdir(TestProcesses.startdir)
 
-    def test_collisionProtection(self):
+    def test_collision_protection(self):
         """
         If tempfile.gettempdir() is used for dir, using same testfile name will
         not collide.
         """
-        sub_tmpdir = tempfile.mkdtemp(dir=self.tmpdir)
+        sub_tmpdir = pathlib.Path(tempfile.mkdtemp(dir=self.tmpdir))
         # Child setup
         # pkg/__init__.py
-        fh = open(os.path.join(sub_tmpdir, "__init__.py"), "w")
-        fh.write("\n")
-        fh.close()
-        # pkg/target_module.py
-        fh = open(os.path.join(sub_tmpdir, "some_module.py"), "w")
-        fh.write("a = 1\n")
-        fh.close()
+        (sub_tmpdir / "__init__.py").write_text("\n", encoding="utf-8")
+        # pkg/some_module.py
+        (sub_tmpdir / "some_module.py").write_text("a = 1\n", encoding="utf-8")
         # pkg/test/__init__.py
-        os.mkdir(os.path.join(sub_tmpdir, "test"))
-        fh = open(os.path.join(sub_tmpdir, "test", "__init__.py"), "w")
-        fh.write("\n")
-        fh.close()
-        # pkg/test/test_target_module.py
-        fh = open(os.path.join(sub_tmpdir, "test", "test_some_module.py"), "w")
-        fh.write(
-            dedent(
-                """
+        os.mkdir(sub_tmpdir / "test")
+        (sub_tmpdir / "test/__init__.py").write_text("\n", encoding="utf-8")
+        # pkg/test/test_some_module.py
+        content = dedent(
+            """
             import os
             import tempfile
             import time
@@ -389,142 +370,123 @@ class TestProcesses(unittest.TestCase):
                         actual = fh.read()
                         fh.close()
                         self.assertEqual(msg, actual)
-            """.format(
-                    os.path.basename(sub_tmpdir)
-                )
-            )
-        )
-        fh.close()
+            """
+        ).format(os.path.basename(sub_tmpdir))
+        (sub_tmpdir / "test/test_some_module.py").write_text(content, encoding="utf-8")
         # Load the tests
         os.chdir(self.tmpdir)
-        tests = self.loader.loadTargets(".")
-        self.args.processes = 2
-        self.args.termcolor = False
         try:
-            run(tests, self.stream, self.args)
-        except KeyboardInterrupt:
-            os.kill(os.getpid(), signal.SIGINT)
-        os.chdir(TestProcesses.startdir)
+            tests = self.loader.loadTargets(".")
+            self.args.processes = 2
+            self.args.termcolor = False
+            try:
+                run(tests, self.stream, self.args)
+            except KeyboardInterrupt:
+                os.kill(os.getpid(), signal.SIGINT)
+        finally:
+            os.chdir(TestProcesses.startdir)
         self.assertIn("OK", self.stream.getvalue())
 
-    def test_detectNumProcesses(self):
+    def test_detect_num_processes(self):
         """
         args.processes = 0 causes auto-detection of number of processes.
         """
-        sub_tmpdir = tempfile.mkdtemp(dir=self.tmpdir)
-        # pkg/__init__.py
-        fh = open(os.path.join(sub_tmpdir, "__init__.py"), "w")
-        fh.write("\n")
-        fh.close()
-        fh = open(os.path.join(sub_tmpdir, "test_autoprocesses.py"), "w")
-        fh.write(
-            dedent(
-                """
+        sub_tmpdir = pathlib.Path(tempfile.mkdtemp(dir=self.tmpdir))
+        (sub_tmpdir / "__init__.py").write_text("\n", encoding="utf-8")
+        content = dedent(
+            """
             import unittest
             class A(unittest.TestCase):
                 def testPasses(self):
                     pass"""
-            )
         )
-        fh.close()
+        (sub_tmpdir / "test_detectNumProcesses.py").write_text(content, encoding="utf-8")
         # Load the tests
         os.chdir(self.tmpdir)
-        tests = self.loader.loadTargets(".")
-        self.args.processes = 0
-        run(tests, self.stream, self.args)
-        os.chdir(TestProcesses.startdir)
+        try:
+            tests = self.loader.loadTargets(".")
+            self.args.processes = 0
+            run(tests, self.stream, self.args)
+        finally:
+            os.chdir(TestProcesses.startdir)
         self.assertIn("OK", self.stream.getvalue())
 
-    def test_runCoverage(self):
+    def test_run_coverage(self):
         """
         Running coverage in process mode doesn't crash
         """
         try:
             import coverage
-
-            coverage
-        except:
+        except ImportError:
             self.skipTest("Coverage needs to be installed for this test")
-        sub_tmpdir = tempfile.mkdtemp(dir=self.tmpdir)
-        # pkg/__init__.py
-        fh = open(os.path.join(sub_tmpdir, "__init__.py"), "w")
-        fh.write("\n")
-        fh.close()
-        fh = open(os.path.join(sub_tmpdir, "test_coverage.py"), "w")
-        fh.write(
-            dedent(
-                """
+        sub_tmpdir = pathlib.Path(tempfile.mkdtemp(dir=self.tmpdir))
+        (sub_tmpdir / "__init__.py").write_text("\n", encoding="utf-8")
+        content = dedent(
+            """
             import unittest
             class A(unittest.TestCase):
                 def testPasses(self):
                     pass"""
-            )
         )
-        fh.close()
+        (sub_tmpdir / "test_coverage.py").write_text(content, encoding="utf-8")
         # Load the tests
         os.chdir(self.tmpdir)
-        tests = self.loader.loadTargets(".")
-        self.args.processes = 2
-        self.args.run_coverage = True
-        self.args.cov = MagicMock()
-        run(tests, self.stream, self.args, testing=True)
-        os.chdir(TestProcesses.startdir)
+        try:
+            tests = self.loader.loadTargets(".")
+            self.args.processes = 2
+            self.args.run_coverage = True
+            self.args.cov = mock.MagicMock()
+            run(tests, self.stream, self.args, testing=True)
+        finally:
+            os.chdir(TestProcesses.startdir)
         self.assertIn("OK", self.stream.getvalue())
 
-    def test_badTest(self):
+    def test_bad_test(self):
         """
         Bad syntax in a testfile is caught as a test error.
         """
-        sub_tmpdir = tempfile.mkdtemp(dir=self.tmpdir)
-        # pkg/__init__.py
-        fh = open(os.path.join(sub_tmpdir, "__init__.py"), "w")
-        fh.write("\n")
-        fh.close()
-        # pkg/test/test_target_module.py
-        fh = open(os.path.join(sub_tmpdir, "test_bad_syntax.py"), "w")
-        fh.write("aoeu")
-        fh.close()
+        sub_tmpdir = pathlib.Path(tempfile.mkdtemp(dir=self.tmpdir))
+        (sub_tmpdir / "__init__.py").write_text("\n", encoding="utf-8")
+        (sub_tmpdir / "test_bad_syntax.py").write_text("aoeu", encoding="utf-8")
         # Load the tests
         os.chdir(self.tmpdir)
-        tests = self.loader.loadTargets(".")
-        self.args.processes = 2
-        os.chdir(TestProcesses.startdir)
+        try:
+            tests = self.loader.loadTargets(".")
+            self.args.processes = 2
+        finally:
+            os.chdir(TestProcesses.startdir)
         self.assertRaises(ImportError, run, tests, self.stream, self.args)
 
-    def test_uncaughtException(self):
+    def test_uncaught_exception(self):
         """
         Exceptions that escape the test framework get caught by poolRunner and
         reported as a failure.  For example, the testtools implementation of
         TestCase unwisely (but deliberately) lets SystemExit exceptions
         through.
         """
-        global skip_testtools
         if skip_testtools:
             self.skipTest("testtools must be installed to run this test.")
 
-        sub_tmpdir = tempfile.mkdtemp(dir=self.tmpdir)
+        sub_tmpdir = pathlib.Path(tempfile.mkdtemp(dir=self.tmpdir))
         # pkg/__init__.py
-        fh = open(os.path.join(sub_tmpdir, "__init__.py"), "w")
-        fh.write("\n")
-        fh.close()
-        fh = open(os.path.join(sub_tmpdir, "test_uncaught.py"), "w")
-        fh.write(
-            dedent(
-                """
+        (sub_tmpdir / "__init__.py").write_text("\n", encoding="utf-8")
+        content = dedent(
+            """
             import testtools
             class Uncaught(testtools.TestCase):
                 def test_uncaught(self):
                     raise SystemExit(0)
-                    """
-            )
+            """
         )
-        fh.close()
+        (sub_tmpdir / "test_uncaught.py").write_text(content, encoding="utf-8")
         # Load the tests
         os.chdir(self.tmpdir)
-        tests = self.loader.loadTargets(".")
-        self.args.processes = 2
-        run(tests, self.stream, self.args)
-        os.chdir(TestProcesses.startdir)
+        try:
+            tests = self.loader.loadTargets(".")
+            self.args.processes = 2
+            run(tests, self.stream, self.args)
+        finally:
+            os.chdir(TestProcesses.startdir)
         self.assertIn("FAILED", self.stream.getvalue())
 
     def test_empty(self):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+black
+# coverage[toml] needs to be listed explictly for python < 3.11.
+coverage[toml]; python_full_version<="3.11.0a6"
+django
+mypy
+testtools

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,5 +1,0 @@
-black
-django
-mypy
-testtools
--r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 colorama
-coverage[toml]
+coverage
 lxml
 setuptools
 unidecode

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,6 +71,8 @@ install_requires = file:requirements.txt
 include_package_data = True
 packages = find:
 
+[options.extras_require]
+dev = file:requirements-dev.txt
 
 [options.package_data]
 green = VERSION, shell_completion.sh


### PR DESCRIPTION
Improve setup.cfg to perform local dev installs more simply and add a make target that uses vanilla python containers of supported versions for local development.

The new `make test-on-containers` runs under 2m on a M1 Pro machine and runs our tests against python 3.8, 3.9, 3.10, 3.11 and 3.12.0.