### PR TITLE
Add more typing to the codebase and minor fixes.

### DIFF
--- a/green/cmdline.py
+++ b/green/cmdline.py
@@ -1,3 +1,5 @@
+"""The green command line entry point."""
+
 from __future__ import annotations
 
 
@@ -53,7 +55,8 @@ def _main(argv: Sequence[str] | None, testing: bool) -> int:
 
     # Add debug logging for stuff that happened before this point here
     if config.files_loaded:
-        debug("Loaded config file(s): {}".format(", ".join(config.files_loaded)))
+        loaded_files = ", ".join(str(path) for path in config.files_loaded)
+        debug(f"Loaded config file(s): {loaded_files}")
 
     # Discover/Load the test suite
     if testing:
@@ -81,7 +84,7 @@ def _main(argv: Sequence[str] | None, testing: bool) -> int:
     return int(not result.wasSuccessful())
 
 
-def main(argv: Sequence[str] | None = None, testing: bool = False):
+def main(argv: Sequence[str] | None = None, testing: bool = False) -> int:
     # create the temp dir only once (i.e., not while in the recursed call)
     if not os.environ.get("TMPDIR"):  # pragma: nocover
         try:
@@ -97,6 +100,7 @@ def main(argv: Sequence[str] | None = None, testing: bool = False):
             if os_error.errno == 39:
                 # "Directory not empty" when trying to delete the temp dir can just be a warning
                 print(f"warning: {os_error.strerror}")
+                return 0
             else:
                 raise os_error
     else:

--- a/green/djangorunner.py
+++ b/green/djangorunner.py
@@ -10,10 +10,10 @@ To make the change permanent for your project, in settings.py add:
 
 from __future__ import annotations
 
-from argparse import Namespace
+from argparse import ArgumentParser, Namespace
 import os
 import sys
-from typing import Sequence
+from typing import Any, Final, Sequence
 
 from green.config import mergeConfig
 from green.loader import GreenTestLoader
@@ -24,11 +24,11 @@ from green.suite import GreenTestSuite
 # If we're not being run from an actual django project, set up django config
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "green.djangorunner")
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
-SECRET_KEY = ")9^_e(=cisybdt4m4+fs+_wb%d$!9mpcoy0um^alvx%gexj#jv"
+SECRET_KEY: Final[str] = ")9^_e(=cisybdt4m4+fs+_wb%d$!9mpcoy0um^alvx%gexj#jv"
 DEBUG = True
 TEMPLATE_DEBUG = True
 ALLOWED_HOSTS: Sequence[str] = []
-INSTALLED_APPS = (
+INSTALLED_APPS: Final[Sequence[str]] = (
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
@@ -37,7 +37,7 @@ INSTALLED_APPS = (
     "django.contrib.staticfiles",
     "myapp",
 )
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE_CLASSES: Final[Sequence[str]] = (
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -46,24 +46,24 @@ MIDDLEWARE_CLASSES = (
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 )
-ROOT_URLCONF = "myproj.urls"
-WSGI_APPLICATION = "myproj.wsgi.application"
-DATABASES = {
+ROOT_URLCONF: Final[str] = "myproj.urls"
+WSGI_APPLICATION: Final[str] = "myproj.wsgi.application"
+DATABASES: Final[dict[str, dict[str, str]]] = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
         "NAME": os.path.join(BASE_DIR, "db.sqlite3"),
     }
 }
-LANGUAGE_CODE = "en-us"
-TIME_ZONE = "UTC"
+LANGUAGE_CODE: Final[str] = "en-us"
+TIME_ZONE: Final[str] = "UTC"
 USE_I18N = True
 USE_L10N = True
 USE_TZ = True
-STATIC_URL = "/static/"
+STATIC_URL: Final[str] = "/static/"
 # End of django fake config stuff
 
 
-def django_missing():
+def django_missing() -> None:
     raise ImportError("No django module installed")
 
 
@@ -75,13 +75,13 @@ try:
     from django.test.runner import DiscoverRunner
 
     class DjangoRunner(DiscoverRunner):
-        def __init__(self, verbose=-1, **kwargs):
+        def __init__(self, verbose: int = -1, **kwargs):
             super().__init__(**kwargs)
             self.verbose = verbose
             self.loader = GreenTestLoader()
 
         @classmethod
-        def add_arguments(cls, parser):
+        def add_arguments(cls, parser: ArgumentParser) -> None:
             parser.add_argument(
                 "--green-verbosity",
                 action="store",
@@ -94,7 +94,14 @@ try:
             )
             super().add_arguments(parser)
 
-        def run_tests(self, test_labels, extra_tests=None, **kwargs):
+        # FIXME: extra_tests is not used, we should either use it or update the
+        #  documentation accordingly.
+        def run_tests(
+            self,
+            test_labels: list[str] | tuple[str, ...],
+            extra_tests: Any = None,
+            **kwargs: Any,
+        ):
             """
             Run the unit tests for all the test labels in the provided list.
 
@@ -111,7 +118,7 @@ try:
             django_db = self.setup_databases()
 
             # Green
-            if type(test_labels) == tuple:
+            if isinstance(test_labels, tuple):
                 test_labels = list(test_labels)
             else:
                 raise ValueError("test_labels should be a tuple of strings")

--- a/green/examples.py
+++ b/green/examples.py
@@ -2,53 +2,54 @@ from __future__ import annotations
 
 import sys
 import unittest
+from typing import Final
 
-doctest_modules = ["green.examples"]
+doctest_modules: Final[list[str]] = ["green.examples"]
 
 
 class TestStates(unittest.TestCase):
-    def test0Pass(self):
+    def test0Pass(self) -> None:
         """
         This test will print output to stdout, and then pass.
         """
         print("Sunshine and daisies")
 
-    def test1Fail(self):
+    def test1Fail(self) -> None:
         """
         This test will print output to stderr, and then fail an assertion.
         """
         sys.stderr.write("Doom and gloom.\n")
         self.assertTrue(False)
 
-    def test2Error(self):
+    def test2Error(self) -> None:
         """
         An Exception will be raised (and not caught) while running this test.
         """
         raise Exception
 
     @unittest.skip("This is the 'reason' portion of the skipped test.")
-    def test3Skip(self):
+    def test3Skip(self) -> None:
         """
         This test will be skipped.
         """
         pass
 
     @unittest.expectedFailure
-    def test4ExpectedFailure(self):
+    def test4ExpectedFailure(self) -> None:
         """
         This test will fail, but we expect it to.
         """
         self.assertEqual(True, False)
 
     @unittest.expectedFailure
-    def test5UnexpectedPass(self):
+    def test5UnexpectedPass(self) -> None:
         """
         This test will pass, but we expected it to fail!
         """
         pass
 
 
-def some_function():
+def some_function() -> int:
     """
     This will fail because some_function() does not, in fact, return 100.
     >>> some_function()
@@ -58,7 +59,7 @@ def some_function():
 
 
 class MyClass:
-    def my_method(self):
+    def my_method(self) -> str:
         """
         This will pass.
         >>> s = MyClass()

--- a/green/process.py
+++ b/green/process.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 # Super-useful debug function for finding problems in the subprocesses, and it
 # even works on windows
-def ddebug(msg: str, err: ExcInfoType | None = None):  # pragma: no cover
+def ddebug(msg: str, err: ExcInfoType | None = None) -> None:  # pragma: no cover
     """
     err can be an instance of sys.exc_info() -- which is the latest traceback
     info
@@ -48,12 +48,12 @@ class ProcessLogger:
     instead of having process crashes be silent.
     """
 
-    def __init__(self, callable: Callable):
+    def __init__(self, callable: Callable) -> None:
         self.__callable = callable
 
     def __call__(self, *args, **kwargs):
         try:
-            result = self.__callable(*args, **kwargs)
+            return self.__callable(*args, **kwargs)
         except Exception:
             # Here we add some debugging help. If multiprocessing's
             # debugging is on, it will arrange to log the traceback
@@ -65,9 +65,6 @@ class ProcessLogger:
             # Re-raise the original exception so the Pool worker can
             # clean up
             raise
-
-        # It was fine, give a normal answer
-        return result
 
 
 class LoggingDaemonlessPool(Pool):
@@ -82,9 +79,6 @@ class LoggingDaemonlessPool(Pool):
     def Process(ctx, *args, **kwargs):
         return ctx.Process(daemon=False, *args, **kwargs)
 
-    # FIXME: `kwargs={}` is dangerous as the empty dict is declared at import time
-    # and becomes a shared object between all instances of LoggingDaemonlessPool.
-    # In short, it is a global variable that is mutable.
     def apply_async(
         self,
         func: Callable,

--- a/green/suite.py
+++ b/green/suite.py
@@ -8,7 +8,7 @@ from unittest import util
 import unittest
 from io import StringIO
 
-from green.config import default_args
+from green.config import get_default_args
 from green.output import GreenStream
 
 
@@ -26,6 +26,7 @@ class GreenTestSuite(TestSuite):
         # You should either set GreenTestSuite.args before instantiation, or
         # pass args into __init__
         self._removed_tests = 0
+        default_args = get_default_args()
         self.allow_stdout = default_args.allow_stdout
         self.full_test_pattern = "test" + default_args.test_pattern
         self.customize(args)

--- a/green/test/test_junit.py
+++ b/green/test/test_junit.py
@@ -1,4 +1,4 @@
-from green.config import default_args
+from green.config import get_default_args
 from green.output import GreenStream
 from green.junit import JUnitXML, JUnitDialect, Verdict
 from green.result import GreenTestResult, ProtoTest, proto_error
@@ -23,7 +23,9 @@ def test(module, class_name, method_name):
 class JUnitXMLReportIsGenerated(TestCase):
     def setUp(self):
         self._destination = StringIO()
-        self._test_results = GreenTestResult(default_args, GreenStream(StringIO()))
+        self._test_results = GreenTestResult(
+            get_default_args(), GreenStream(StringIO())
+        )
         self._test_results.timeTaken = 4.06
         self._adapter = JUnitXML()
 

--- a/green/test/test_result.py
+++ b/green/test/test_result.py
@@ -11,7 +11,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 import tempfile
 
-from green.config import default_args
+from green.config import get_default_args
 from green.output import Colors, GreenStream
 from green.result import (
     GreenTestResult,
@@ -364,7 +364,7 @@ class TestProtoTest(unittest.TestCase):
 
 class TestGreenTestResult(unittest.TestCase):
     def setUp(self):
-        self.args = copy.deepcopy(default_args)
+        self.args = copy.deepcopy(get_default_args())
         self.stream = StringIO()
 
     def tearDown(self):
@@ -834,7 +834,7 @@ class TestGreenTestResult(unittest.TestCase):
 class TestGreenTestResultAdds(unittest.TestCase):
     def setUp(self):
         self.stream = StringIO()
-        self.args = copy.deepcopy(default_args)
+        self.args = copy.deepcopy(get_default_args())
         self.args.verbose = 0
         self.gtr = GreenTestResult(self.args, GreenStream(self.stream))
         self.gtr._reportOutcome = MagicMock()
@@ -1084,7 +1084,7 @@ class TestGreenTestResultAdds(unittest.TestCase):
 
 class TestGreenTestRunCoverage(unittest.TestCase):
     def setUp(self):
-        self.args = copy.deepcopy(default_args)
+        self.args = copy.deepcopy(get_default_args())
 
         cov_file = tempfile.NamedTemporaryFile(delete=False)
         cov_file.close()

--- a/green/test/test_runner.py
+++ b/green/test/test_runner.py
@@ -12,7 +12,7 @@ import unittest
 from unittest import mock
 import weakref
 
-from green.config import default_args
+from green.config import get_default_args
 from green.exceptions import InitializerOrFinalizerError
 from green.loader import GreenTestLoader
 from green.output import GreenStream
@@ -108,7 +108,7 @@ class TestRun(unittest.TestCase):
         cls.startdir = None
 
     def setUp(self):
-        self.args = copy.deepcopy(default_args)
+        self.args = copy.deepcopy(get_default_args())
         self.stream = StringIO()
         self.tmpdir = tempfile.mkdtemp()
         self.loader = GreenTestLoader()
@@ -284,7 +284,7 @@ class TestProcesses(unittest.TestCase):
         os.chdir(self.container_dir)
         self.tmpdir = tempfile.mkdtemp(dir=self.container_dir)
         self.stream = StringIO()
-        self.args = copy.deepcopy(default_args)
+        self.args = copy.deepcopy(get_default_args())
         self.loader = GreenTestLoader()
 
     def tearDown(self):

--- a/green/test/test_suite.py
+++ b/green/test/test_suite.py
@@ -6,7 +6,7 @@ from textwrap import dedent
 import unittest
 from unittest.mock import MagicMock
 
-from green.config import default_args
+from green.config import get_default_args
 from green.loader import GreenTestLoader
 from green.runner import run
 from green.suite import GreenTestSuite
@@ -23,6 +23,7 @@ class TestGreenTestSuite(unittest.TestCase):
         """
         Passing in default arguments causes attributes to be set.
         """
+        default_args = get_default_args()
         gts = GreenTestSuite(args=default_args)
         self.assertEqual(gts.allow_stdout, default_args.allow_stdout)
 
@@ -31,7 +32,7 @@ class TestGreenTestSuite(unittest.TestCase):
         When result.shouldStop == True, the suite should exit early.
         """
         mock_test = MagicMock()
-        gts = GreenTestSuite(args=default_args)
+        gts = GreenTestSuite(args=get_default_args())
         gts._tests = (mock_test,)
         mock_result = MagicMock()
         mock_result.shouldStop = True
@@ -43,7 +44,7 @@ class TestGreenTestSuite(unittest.TestCase):
         """
         mock_test = MagicMock()
         mock_test.__iter__.side_effect = TypeError
-        gts = GreenTestSuite(args=default_args)
+        gts = GreenTestSuite(args=get_default_args())
         gts._tests = (mock_test,)
         mock_result = MagicMock()
         mock_result._moduleSetUpFailed = True
@@ -57,7 +58,7 @@ class TestGreenTestSuite(unittest.TestCase):
         mock_module = MagicMock()
         mock_test = MagicMock()
         mock_err = MagicMock()
-        args = copy.deepcopy(default_args)
+        args = copy.deepcopy(get_default_args())
         gts = GreenTestSuite(args=args)
         gts._get_previous_module = mock_module
         mock_result = MagicMock()
@@ -75,7 +76,7 @@ class TestGreenTestSuite(unittest.TestCase):
         mock_test._testMethodName = "test_hello"
         mock_test2 = MagicMock()
         mock_test2._testMethodName = "test_goodbye"
-        args = copy.deepcopy(default_args)
+        args = copy.deepcopy(get_default_args())
         args.test_pattern = "_good*"
         gts = GreenTestSuite(args=args)
         gts.addTest(mock_test)
@@ -100,7 +101,7 @@ class TestGreenTestSuite(unittest.TestCase):
         """
         If SkipTest is raised in setUpClass, then the test gets skipped
         """
-        gts = GreenTestSuite(args=default_args)
+        gts = GreenTestSuite(args=get_default_args())
         mock_test = MagicMock()
         mock_result = MagicMock()
         mock_class = MagicMock()
@@ -129,7 +130,7 @@ class TestFunctional(unittest.TestCase):
         cls.startdir = None
 
     def setUp(self):
-        self.args = copy.deepcopy(default_args)
+        self.args = copy.deepcopy(get_default_args())
         self.stream = StringIO()
         self.tmpdir = tempfile.mkdtemp()
         self.loader = GreenTestLoader()
@@ -181,7 +182,7 @@ class TestModuleTeardown(unittest.TestCase):
         cls.startdir = None
 
     def setUp(self):
-        self.args = copy.deepcopy(default_args)
+        self.args = copy.deepcopy(get_default_args())
         self.stream = StringIO()
         self.tmpdir = tempfile.mkdtemp()
         self.loader = GreenTestLoader()


### PR DESCRIPTION
- Improve maintainability of the codebase while leaving the business logic the same.
- Remove more code specific to python 2.7.
- Use sets and tuples instead of lists when they are more efficient.
- Remove redundant `str()` calls.
- Move default_args instantiation to runtime instead of import time.