### PR TITLE
Set environment name for the releases

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -9,7 +9,7 @@ jobs:
     name: Upload release to PyPI Test
     runs-on: ubuntu-latest
     environment:
-      name: pypi
+      name: release-test
       url: https://test.pypi.org/p/green
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     environment:
-      name: pypi
+      name: release
       url: https://pypi.org/p/green
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 #### Date TBD
 
 # Version 4.0.1
-#### 14 Feb 2024
+#### 15 Feb 2024
 
 Note that we are explicitly flagging Python 3.12.1 as incompatible due to a regression
 that was fixed in 3.12.2.

--- a/release.md
+++ b/release.md
@@ -5,6 +5,6 @@ Steps to Release
 
 2. Push and merge to the main branch.
 
-3. Trigger the Release Test workflow in GitHub Actions. Optional but recommended.
+3. Trigger the Release Test workflow in GitHub Actions then approve the run on the release-test environment. Optional but recommended.
 
-4. Create a new release in GitHub with a tag that mirrors the version, the GH action will take care of the rest.
+4. Create a new release in GitHub with a tag that mirrors the version, the GH action will take care of the rest after beeing approved to run.


### PR DESCRIPTION
The 'deployment' environments are required to match in the actions.

Validated with the release-test environment which did publish from the action of the official repo.

Once this is merged to main we should be able release 100% from the GH UI.

https://test.pypi.org/project/green/4.0.1/

Released through:
https://github.com/CleanCut/green/actions/runs/7912354962/job/21597969386

```
Checking dist/green-4.0.1.tar.gz: PASSED
Uploading distributions to https://test.pypi.org/legacy/
Uploading green-4.0.1.tar.gz
25l
[ .. snip .. ]
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 85.7/85.7 kB • 00:00 • 183.2 MB/s
25h
View at:
https://test.pypi.org/project/green/4.0.1/
```