### PR TITLE
Fix test_time being always 0.0

### DIFF
--- a/green/result.py
+++ b/green/result.py
@@ -329,8 +329,8 @@ class ProtoTestResult(BaseTestResult):
         Called before each test runs.
         """
         test = proto_test(test)
-        self.start_time = time.time()
         self.reinitialize()
+        self.start_time = time.time()
         if self.start_callback:
             self.start_callback(test)
 

--- a/green/test/test_process.py
+++ b/green/test/test_process.py
@@ -103,10 +103,12 @@ class TestPoolRunner(unittest.TestCase):
         )
         fh.close()
         module_name = basename + ".test_pool_runner_dotted.A.testPass"
-        result = Queue()
-        poolRunner(module_name, result, 1)
-        result.get()
-        self.assertEqual(len(result.get().passing), 1)
+        results = Queue()
+        poolRunner(module_name, results, 1)
+        results.get()
+        result = results.get()
+        self.assertEqual(len(result.passing), 1)
+        self.assertGreater(float(result.test_time), 0)
 
     def test_SyntaxErrorInUnitTest(self):
         """

--- a/green/test/test_result.py
+++ b/green/test/test_result.py
@@ -104,6 +104,16 @@ class TestBaseTestResult(unittest.TestCase):
 
 
 class TestProtoTestResult(unittest.TestCase):
+    def test_startStop(self):
+        """
+        startTest/stopTest work correctly
+        """
+        ptr = ProtoTestResult()
+        test = proto_test(MagicMock())
+        ptr.startTest(test)
+        ptr.stopTest(test)
+        self.assertGreater(float(ptr.test_time), 0)
+
     def test_addSuccess(self):
         """
         addSuccess adds a test correctly

--- a/green/test/test_result.py
+++ b/green/test/test_result.py
@@ -110,9 +110,10 @@ class TestProtoTestResult(unittest.TestCase):
         """
         ptr = ProtoTestResult()
         test = proto_test(MagicMock())
-        ptr.startTest(test)
-        ptr.stopTest(test)
-        self.assertGreater(float(ptr.test_time), 0)
+        with patch("time.time", side_effect=[101, 123]):
+            ptr.startTest(test)
+            ptr.stopTest(test)
+        self.assertEqual(float(ptr.test_time), 22)
 
     def test_addSuccess(self):
         """


### PR DESCRIPTION
The bug was introduced in commit 651ab467e371b42e6205b9c3d223f2e1f50e4b0a when setting start_time = 0.0 was added to ProtoTestResult.reinitialize().