### PR TITLE
Fix zero coverage in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install
         run: |
           python -m pip install --upgrade pip
-          pip install --upgrade '.[dev]'
+          pip install --upgrade -e '.[dev]'
 
       - name: Format
         run: black --check --diff green example


### PR DESCRIPTION
Install the project in editable mode, otherwise we run the copy of the code in site-packages which does not match the expected source location.

Closes #289