### PR TITLE
Use forkserver start method for multiprocessing

### DIFF
--- a/green/cmdline.py
+++ b/green/cmdline.py
@@ -93,8 +93,15 @@ def main(argv: Sequence[str] | None = None, testing: bool = False) -> int:
         temp_dir_for_tests = tempfile.mkdtemp()
         atexit.register(lambda: shutil.rmtree(temp_dir_for_tests, ignore_errors=True))
         os.environ["TMPDIR"] = temp_dir_for_tests
+        prev_tempdir = tempfile.tempdir
         tempfile.tempdir = temp_dir_for_tests
-    return _main(argv, testing)
+        try:
+            return _main(argv, testing)
+        finally:
+            del os.environ["TMPDIR"]
+            tempfile.tempdir = prev_tempdir
+    else:
+        return _main(argv, testing)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/green/config.py
+++ b/green/config.py
@@ -12,7 +12,6 @@ import configparser  # pragma: no cover
 import copy  # pragma: no cover
 import functools  # pragma: no cover
 import logging  # pragma: no cover
-import multiprocessing  # pragma: no cover
 import os  # pragma: no cover
 import pathlib  # pragma: no cover
 import sys  # pragma: no cover
@@ -36,7 +35,7 @@ def get_default_args() -> argparse.Namespace:
     """
     return argparse.Namespace(  # pragma: no cover
         targets=["."],  # Not in configs
-        processes=multiprocessing.cpu_count(),
+        processes=os.cpu_count(),
         initializer="",
         finalizer="",
         maxtasksperchild=None,


### PR DESCRIPTION
Use forkserver when available to avoid issues with forking multi-threaded processes. See https://github.com/python/cpython/issues/84559 for more context.

This also removes a warning when running on python 3.12 than can be seen in CI:

>/opt/hostedtoolcache/Python/3.12.2/x64/lib/python3.12/multiprocessing/popen_fork.py:66: DeprecationWarning: This process (pid=1991) is multi-threaded, use of fork() may lead to deadlocks in the child.
>    self.pid = os.fork()
