### PR TITLE
Add download stats badge.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 #### Date TBD
 
+* Use forkserver start method for multiprocessing by @eltoder in https://github.com/CleanCut/green/pull/296
+
 # Version 4.0.2
 #### 18 Apr 2024
 

--- a/README-pypi.rst
+++ b/README-pypi.rst
@@ -1,6 +1,11 @@
 Green
 =====
 
+[![Version](https://img.shields.io/pypi/v/green.svg?style=flat)](https://pypi.python.org/pypi/green)
+[![PyPI downloads](https://img.shields.io/pypi/dm/green.svg)](https://pypistats.org/packages/green)
+[![CI Status](https://github.com/CleanCut/green/workflows/CI/badge.svg)](https://github.com/CleanCut/green/actions)
+[![Coverage Status](https://img.shields.io/coveralls/CleanCut/green.svg?style=flat)](https://coveralls.io/r/CleanCut/green?branch=main)
+
 Green is a clean, colorful, fast python test runner.
 
 Documentation

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
+# Green
+
 [![Version](https://img.shields.io/pypi/v/green.svg?style=flat)](https://pypi.python.org/pypi/green)
+[![PyPI downloads](https://img.shields.io/pypi/dm/green.svg)](https://pypistats.org/packages/green)
 [![CI Status](https://github.com/CleanCut/green/workflows/CI/badge.svg)](https://github.com/CleanCut/green/actions)
 [![Coverage Status](https://img.shields.io/coveralls/CleanCut/green.svg?style=flat)](https://coveralls.io/r/CleanCut/green?branch=main)
 
-# Green -- A clean, colorful, fast python test runner.
+A clean, colorful, fast python test runner.
+
 
 Features
 --------


### PR DESCRIPTION
This adds a downloads stats badge to the main readme which helps show the popularity of green.

Moved the text around a bit to be consistent with other popular python packages and added the badges to the readme that is published on pypi.org.
